### PR TITLE
Adding step logs for image pull errors

### DIFF
--- a/internal/docker/jsonmessage/jsonmessage.go
+++ b/internal/docker/jsonmessage/jsonmessage.go
@@ -45,6 +45,7 @@ func Copy(in io.Reader, out io.Writer) error {
 			if jm.Error.Code == 401 { // nolint:gomnd
 				return fmt.Errorf("authentication is required")
 			}
+			fmt.Fprintf(out, "%s\n", jm.Error)
 			return jm.Error
 		}
 


### PR DESCRIPTION
If image was not pulled due to storage issue, earlier it was just giving image not found error which is misleading. Actual err:
`failed to register layer: re-exec error: exit status 1: output: BackupWrite \\\\?\\C:\\ProgramData\\docker\\windowsfilter\\621b3a2539d0808319774d93840dd04d453b5a4fbca1c8580fd5c6822d972395\\UtilityVM\\Files\\Windows\\Fonts\\msyh.ttc: There is not enough space on the disk`