### PR TITLE
append usr/local/bin path for osx docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-lite-engine
-lite-engine.exe
+lite-engine*
 .env
 get-docker.sh
 /release/
-/lite-engine-windows-amd64.exe
-/lite-engine-darwin-amd64
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ lite-engine.exe
 .env
 get-docker.sh
 /release/
+/lite-engine-windows-amd64.exe
+/lite-engine-darwin-amd64

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -32,6 +32,7 @@ func PrepareSystem() {
 }
 
 const windowsString = "windows"
+const osxString = "darwin"
 
 func GitInstalled(instanceInfo InstanceInfo) (installed bool) {
 	logrus.Infoln("checking git is installed")
@@ -54,6 +55,14 @@ func DockerInstalled(instanceInfo InstanceInfo) (installed bool) {
 	switch instanceInfo.osType {
 	case windowsString:
 		logrus.Infoln("windows: we should check docker installation here")
+	case osxString:
+		cmd := exec.Command("/usr/local/bin/docker", "ps")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			return false
+		}
 	default:
 		cmd := exec.Command("docker", "ps")
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
This is required for osx support. "docker" command won't work. You need to pass full path.