### PR TITLE
Remove drone & git checks from health check api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,11 +10,8 @@ import (
 
 type (
 	HealthResponse struct {
-		Version         string `json:"version"`
-		DockerInstalled bool   `json:"docker_installed"`
-		GitInstalled    bool   `json:"git_installed"`
-		LiteEngineLog   string `json:"lite_engine_log"`
-		OK              bool   `json:"ok"`
+		Version string `json:"version"`
+		OK      bool   `json:"ok"`
 	}
 
 	SetupRequest struct {

--- a/handler/health.go
+++ b/handler/health.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/harness/lite-engine/api"
-	"github.com/harness/lite-engine/setup"
 	"github.com/harness/lite-engine/version"
 	"github.com/sirupsen/logrus"
 )
@@ -16,16 +15,10 @@ import (
 func HandleHealth() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logrus.Infoln("handler: HandleHealth()")
-		instanceInfo := setup.GetInstanceInfo()
-		dockerOK := setup.DockerInstalled(instanceInfo)
-		gitOK := setup.GitInstalled(instanceInfo)
 		version := version.Version
 		response := api.HealthResponse{
-			Version:         version,
-			DockerInstalled: dockerOK,
-			GitInstalled:    gitOK,
-			LiteEngineLog:   setup.GetLiteEngineLog(instanceInfo),
-			OK:              dockerOK && gitOK,
+			Version: version,
+			OK:      true,
 		}
 		WriteJSON(w, response, http.StatusOK)
 	}


### PR DESCRIPTION
DockerInstalled, GitInstalled & LiteEngineLogs variables are not used in runner. So, it will be backward compatible.