### PR TITLE
Add retries for image pull op

### DIFF
--- a/engine/docker/docker.go
+++ b/engine/docker/docker.go
@@ -382,14 +382,18 @@ func (e *Docker) pullImageWithRetries(ctx context.Context, image string,
 			WithField("image", image).
 			Warnln("failed to pull image")
 
-		if errdefs.IsNotFound(err) || errdefs.IsUnauthorized(err) ||
-			errdefs.IsInvalidParameter(err) || errdefs.IsForbidden(err) ||
-			errdefs.IsCancelled(err) || errdefs.IsDeadline(err) {
+		switch {
+		case errdefs.IsNotFound(err),
+			errdefs.IsUnauthorized(err),
+			errdefs.IsInvalidParameter(err),
+			errdefs.IsForbidden(err),
+			errdefs.IsCancelled(err),
+			errdefs.IsDeadline(err):
 			return err
-		}
-
-		if i < 3 {
-			logrus.WithField("image", image).Infoln("retrying image pull")
+		default:
+			if i < 3 {
+				logrus.WithField("image", image).Infoln("retrying image pull")
+			}
 		}
 		time.Sleep(time.Millisecond * 100)
 	}

--- a/engine/docker/docker.go
+++ b/engine/docker/docker.go
@@ -396,7 +396,7 @@ func (e *Docker) pullImageWithRetries(ctx context.Context, image string,
 			errdefs.IsDeadline(err):
 			return err
 		default:
-			if i < 3 {
+			if i < imageMaxRetries {
 				logrus.WithField("image", image).Infoln("retrying image pull")
 			}
 		}


### PR DESCRIPTION
Some CI pipelines failed with errors:
1. Error response from daemon: Get "https://registry-1.docker.io/v2/mikesir87/aws-cli/manifests/sha256:064523bff733063ccabe2110314c534a4c6a0ad79ee3488e536a6c5de37c6835": EOF
2. Error response from daemon: Head "https://registry-1.docker.io/v2/harness/drone-git/manifests/1.2.3": Get "https://auth.docker.io/token?scope=repository%3Aharness%2Fdrone-git%3Apull&service=registry.docker.io": EOF

Added retries to reduce these issues.