### PR TITLE
overload .env variables if env file present

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -30,11 +30,13 @@ type serverCommand struct {
 }
 
 func (c *serverCommand) run(*kingpin.ParseContext) error {
-	loadEnvErr := godotenv.Load(c.envfile)
-	if loadEnvErr != nil {
-		logrus.
-			WithError(loadEnvErr).
-			Errorln("cannot load env file")
+	if c.envfile != "" {
+		loadEnvErr := godotenv.Overload(c.envfile)
+		if loadEnvErr != nil {
+			logrus.
+				WithError(loadEnvErr).
+				Errorln("cannot load env file")
+		}
 	}
 	// load the system configuration from the environment.
 	loadedConfig, err := config.Load()


### PR DESCRIPTION
Overload .env variables if env file present. This is for ensuring that PATH variable value of host machine is set and not cloud init script one