### PR TITLE
(fix): Cloud Lite Engine does not send commit_link data

### DIFF
--- a/ti/callgraph/upload.go
+++ b/ti/callgraph/upload.go
@@ -52,7 +52,7 @@ func Upload(ctx context.Context, stepID string, timeMs int64, log *logrus.Logger
 	}
 
 	c := client.NewHTTPClient(cfg.URL, cfg.Token, cfg.AccountID, cfg.OrgID, cfg.ProjectID,
-		cfg.PipelineID, cfg.BuildID, cfg.StageID, cfg.Repo, cfg.Sha, false)
+		cfg.PipelineID, cfg.BuildID, cfg.StageID, cfg.Repo, cfg.Sha, cfg.CommitLink, false)
 	if cgErr := c.UploadCg(ctx, stepID, source, target, timeMs, encCg); cgErr != nil {
 		return cgErr
 	}

--- a/ti/client/http.go
+++ b/ti/client/http.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	dbEndpoint            = "/reports/write?accountId=%s&orgId=%s&projectId=%s&pipelineId=%s&buildId=%s&stageId=%s&stepId=%s&report=%s&repo=%s&sha=%s"
+	dbEndpoint            = "/reports/write?accountId=%s&orgId=%s&projectId=%s&pipelineId=%s&buildId=%s&stageId=%s&stepId=%s&report=%s&repo=%s&sha=%s&commitLink=%s"
 	testEndpoint          = "/tests/select?accountId=%s&orgId=%s&projectId=%s&pipelineId=%s&buildId=%s&stageId=%s&stepId=%s&repo=%s&sha=%s&source=%s&target=%s"
 	cgEndpoint            = "/tests/uploadcg?accountId=%s&orgId=%s&projectId=%s&pipelineId=%s&buildId=%s&stageId=%s&stepId=%s&repo=%s&sha=%s&source=%s&target=%s&timeMs=%d"
 	getTestsTimesEndpoint = "/tests/timedata?accountId=%s&orgId=%s&projectId=%s&pipelineId=%s"
@@ -36,7 +36,7 @@ var defaultClient = &http.Client{
 }
 
 // NewHTTPClient returns a new HTTPClient.
-func NewHTTPClient(endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stageID, repo, sha string,
+func NewHTTPClient(endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stageID, repo, sha, commitLink string,
 	skipverify bool) *HTTPClient {
 	client := &HTTPClient{
 		Endpoint:   endpoint,
@@ -49,6 +49,7 @@ func NewHTTPClient(endpoint, token, accountID, orgID, projectID, pipelineID, bui
 		StageID:    stageID,
 		Repo:       repo,
 		Sha:        sha,
+		CommitLink: commitLink,
 		SkipVerify: skipverify,
 	}
 	if skipverify {
@@ -80,12 +81,13 @@ type HTTPClient struct {
 	StageID    string
 	Repo       string
 	Sha        string
+	CommitLink string
 	SkipVerify bool
 }
 
 // Write writes test results to the TI server
 func (c *HTTPClient) Write(ctx context.Context, stepID, report string, tests []*ti.TestCase) error {
-	path := fmt.Sprintf(dbEndpoint, c.AccountID, c.OrgID, c.ProjectID, c.PipelineID, c.BuildID, c.StageID, stepID, report, c.Repo, c.Sha)
+	path := fmt.Sprintf(dbEndpoint, c.AccountID, c.OrgID, c.ProjectID, c.PipelineID, c.BuildID, c.StageID, stepID, report, c.Repo, c.Sha, c.CommitLink)
 	_, err := c.do(ctx, c.Endpoint+path, "POST", c.Sha, &tests, nil) //nolint:bodyclose
 	return err
 }

--- a/ti/instrumentation/utils.go
+++ b/ti/instrumentation/utils.go
@@ -48,7 +48,7 @@ func getTestTime(ctx context.Context, splitStrategy string) (map[string]float64,
 		return fileTimesMap, fmt.Errorf("TI config is not provided in setup")
 	}
 	c := client.NewHTTPClient(cfg.URL, cfg.Token, cfg.AccountID, cfg.OrgID, cfg.ProjectID,
-		cfg.PipelineID, cfg.BuildID, cfg.StageID, cfg.Repo, cfg.Sha, false)
+		cfg.PipelineID, cfg.BuildID, cfg.StageID, cfg.Repo, cfg.Sha, cfg.CommitLink, false)
 
 	req := ti.GetTestTimesReq{}
 	var res ti.GetTestTimesResp
@@ -218,7 +218,7 @@ func selectTests(ctx context.Context, workspace string, files []ti.File, runSele
 	req := &ti.SelectTestsReq{SelectAll: !runSelected, Files: files, TiConfig: ticonfig}
 
 	c := client.NewHTTPClient(config.URL, config.Token, config.AccountID, config.OrgID, config.ProjectID,
-		config.PipelineID, config.BuildID, config.StageID, config.Repo, config.Sha, false)
+		config.PipelineID, config.BuildID, config.StageID, config.Repo, config.Sha, config.CommitLink, false)
 	return c.SelectTests(ctx, stepID, source, target, req)
 }
 
@@ -282,7 +282,7 @@ func installAgents(ctx context.Context, baseDir, language, os, arch, framework s
 	config := pipeline.GetState().GetTIConfig()
 
 	c := client.NewHTTPClient(config.URL, config.Token, config.AccountID, config.OrgID, config.ProjectID,
-		config.PipelineID, config.BuildID, config.StageID, config.Repo, config.Sha, false)
+		config.PipelineID, config.BuildID, config.StageID, config.Repo, config.Sha, config.CommitLink, false)
 	log.Infoln("getting TI agent artifact download links")
 	links, err := c.DownloadLink(ctx, language, os, arch, framework)
 	if err != nil {

--- a/ti/report/report.go
+++ b/ti/report/report.go
@@ -48,7 +48,7 @@ func ParseAndUploadTests(ctx context.Context, report api.TestReport, workDir, st
 	}
 
 	c := client.NewHTTPClient(config.URL, config.Token, config.AccountID, config.OrgID, config.ProjectID,
-		config.PipelineID, config.BuildID, config.StageID, config.Repo, config.Sha, false)
+		config.PipelineID, config.BuildID, config.StageID, config.Repo, config.Sha, config.CommitLink, false)
 	if err := c.Write(ctx, stepID, strings.ToLower(report.Kind.String()), tests); err != nil {
 		return err
 	}


### PR DESCRIPTION
Cloud Lite Engine does not send commit_link data to TI service to write into tsdb. This commit fixes this.