### PR TITLE
[fix]: [CI-7224]: Fix output variable not found error

### DIFF
--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -47,7 +47,7 @@ func getOutputVarCmd(entrypoint, outputVars []string, outputFile string) string 
 		} else if isPython {
 			cmd += fmt.Sprintf("with open('%s', 'a') as out_file:\n\tout_file.write('%s=' + os.getenv('%s') + '\\n')\n", outputFile, o, o)
 		} else {
-			cmd += fmt.Sprintf(";echo \"%s=$%s\" >> %s", o, o, outputFile)
+			cmd += fmt.Sprintf("\necho \"%s=$%s\" >> %s", o, o, outputFile)
 		}
 	}
 


### PR DESCRIPTION
If the last statement is a comment then we append the output var command to a comment which also comments it out and it does create an output file. This change puts the output var cmd on a new line to ensure it always executes