### PR TITLE
(feat): add noop client for lite engine operations

### DIFF
--- a/cli/client/http.go
+++ b/cli/client/http.go
@@ -25,6 +25,8 @@ var (
 	healthCheckTimeout = 10 * time.Second
 )
 
+var _ Client = (*HTTPClient)(nil)
+
 // Error represents a json-encoded API error.
 type Error struct {
 	Message string

--- a/cli/client/noop.go
+++ b/cli/client/noop.go
@@ -8,6 +8,8 @@ import (
 	"github.com/harness/lite-engine/api"
 )
 
+var _ Client = (*NoopClient)(nil)
+
 type NoopClient struct {
 	stepResponse *api.PollStepResponse // response to return for the step execution
 	stepErr      error                 // if there's an error in polling the step response

--- a/cli/client/noop.go
+++ b/cli/client/noop.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/harness/lite-engine/api"
+)
+
+type NoopClient struct {
+	stepResponse *api.PollStepResponse // response to return for the step execution
+	stepErr      error                 // if there's an error in polling the step response
+	stepExecTime time.Duration         // how long to wait for the step to return back
+}
+
+func NewNoopClient(r *api.PollStepResponse, err error, time time.Duration) *NoopClient {
+	return &NoopClient{
+		stepResponse: r,
+		stepErr:      err,
+		stepExecTime: time,
+	}
+}
+
+func (*NoopClient) Setup(ctx context.Context, in *api.SetupRequest) (*api.SetupResponse, error) {
+	return &api.SetupResponse{}, nil
+}
+
+func (*NoopClient) Destroy(ctx context.Context, in *api.DestroyRequest) (*api.DestroyResponse, error) {
+	return &api.DestroyResponse{}, nil
+}
+
+func (*NoopClient) StartStep(ctx context.Context, in *api.StartStepRequest) (*api.StartStepResponse, error) {
+	return &api.StartStepResponse{}, nil
+}
+
+func (n *NoopClient) PollStep(ctx context.Context, in *api.PollStepRequest) (*api.PollStepResponse, error) {
+	time.Sleep(n.stepExecTime)
+	return n.stepResponse, n.stepErr
+}
+
+func (n *NoopClient) RetryPollStep(ctx context.Context, in *api.PollStepRequest, timeout time.Duration) (step *api.PollStepResponse, pollError error) {
+	return n.PollStep(ctx, in)
+}
+
+func (*NoopClient) GetStepLogOutput(ctx context.Context, in *api.StreamOutputRequest, w io.Writer) error {
+	return nil
+}
+
+func (*NoopClient) Health(ctx context.Context) (*api.HealthResponse, error) {
+	return &api.HealthResponse{OK: true, Version: "noop"}, nil
+}
+
+func (n *NoopClient) RetryHealth(ctx context.Context, timeout time.Duration) (*api.HealthResponse, error) {
+	return n.Health(ctx)
+}

--- a/cli/client/noop.go
+++ b/cli/client/noop.go
@@ -14,21 +14,27 @@ type NoopClient struct {
 	stepResponse *api.PollStepResponse // response to return for the step execution
 	stepErr      error                 // if there's an error in polling the step response
 	stepExecTime time.Duration         // how long to wait for the step to return back
+	setupTime    time.Duration         // time taken to setup the stage
+	destroyTime  time.Duration         // time taken to destroy the stage
 }
 
-func NewNoopClient(r *api.PollStepResponse, err error, time time.Duration) *NoopClient {
+func NewNoopClient(r *api.PollStepResponse, err error, stepExecTime, setupTime, destroyTime time.Duration) *NoopClient {
 	return &NoopClient{
 		stepResponse: r,
 		stepErr:      err,
-		stepExecTime: time,
+		stepExecTime: stepExecTime,
+		setupTime:    setupTime,
+		destroyTime:  destroyTime,
 	}
 }
 
-func (*NoopClient) Setup(ctx context.Context, in *api.SetupRequest) (*api.SetupResponse, error) {
+func (n *NoopClient) Setup(ctx context.Context, in *api.SetupRequest) (*api.SetupResponse, error) {
+	time.Sleep(n.setupTime)
 	return &api.SetupResponse{}, nil
 }
 
-func (*NoopClient) Destroy(ctx context.Context, in *api.DestroyRequest) (*api.DestroyResponse, error) {
+func (n *NoopClient) Destroy(ctx context.Context, in *api.DestroyRequest) (*api.DestroyResponse, error) {
+	time.Sleep(n.destroyTime)
 	return &api.DestroyResponse{}, nil
 }
 


### PR DESCRIPTION
We want to be able to support easy scale testing in AWS runner without having to interact with the lite engine. This PR adds a noop client to mock out the lite engine ops