### PR TITLE
fix:  [CI-7586]: Increase character limit when parsing Junit XML

### DIFF
--- a/ti/report/parser/junit/junit.go
+++ b/ti/report/parser/junit/junit.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	// buffSize   = 100
-	strMaxSize = 2000 // Keep the last 2k characters in each field.
+	strMaxSize = 4000 // Keep the last 4k characters in each field.
 )
 
 // ParseTests parses XMLs and writes relevant data to the channel


### PR DESCRIPTION
The current limit is 2k and a customer complained about the report fields being truncated. This change bumps this limit to 4k.