### PR TITLE
update lock so that flush() does not return if there is any Write in progress

### DIFF
--- a/livelog/livelog.go
+++ b/livelog/livelog.go
@@ -197,9 +197,9 @@ func (b *Writer) flush() error {
 		return nil
 	}
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	lines := b.copy()
 	b.clear()
-	b.mu.Unlock()
 	if len(lines) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Context here: https://harness.atlassian.net/browse/CI-7973

This should fix the issue VS is seeing for truncated logs