### PR TITLE
[feat]: [CI-8188]: 0777 permission must be given to /tmp/engine

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -57,6 +57,7 @@ func (e *Engine) Setup(ctx context.Context, pipelineConfig *spec.PipelineConfig)
 			vol.HostPath.Path = pathConverter(path)
 
 			if _, err := os.Stat(path); err == nil {
+				_ = os.Chmod(path, 0777)
 				continue
 			}
 
@@ -64,6 +65,7 @@ func (e *Engine) Setup(ctx context.Context, pipelineConfig *spec.PipelineConfig)
 				return errors.Wrap(err,
 					fmt.Sprintf("failed to create directory for host volume path: %q", path))
 			}
+			_ = os.Chmod(path, 0777)
 		}
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -64,7 +64,7 @@ func (e *Engine) Setup(ctx context.Context, pipelineConfig *spec.PipelineConfig)
 			continue
 		}
 
-		if err := os.MkdirAll(path, permissions); err != nil { //nolint:gomnd
+		if err := os.MkdirAll(path, permissions); err != nil {
 			return errors.Wrap(err,
 				fmt.Sprintf("failed to create directory for host volume path: %q", path))
 		}


### PR DESCRIPTION
Currently even though we create the dir with 0777, the default umask of 022 creates the dir with 0755. Hence we need to explicitly chmod to achieve this. Please refer to https://harness.atlassian.net/browse/CI-8107 for more details as to why its needed.