### PR TITLE
add support for lite engine log upload and fix log limit issue

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -27,7 +27,10 @@ type (
 
 	SetupResponse struct{}
 
-	DestroyRequest struct{}
+	DestroyRequest struct {
+		LogDrone bool   `json:"log_drone,omitempty"`
+		LogKey   string `json:"log_key,omitempty"` // key to write the lite engine logs (optional)
+	}
 
 	DestroyResponse struct{}
 

--- a/api/api.go
+++ b/api/api.go
@@ -28,8 +28,9 @@ type (
 	SetupResponse struct{}
 
 	DestroyRequest struct {
-		LogDrone bool   `json:"log_drone,omitempty"`
-		LogKey   string `json:"log_key,omitempty"` // key to write the lite engine logs (optional)
+		LogDrone       bool   `json:"log_drone,omitempty"`
+		LogKey         string `json:"log_key,omitempty"`          // key to write the lite engine logs (optional)
+		LiteEnginePath string `json:"lite_engine_path,omitempty"` // where to find the lite engine logs
 	}
 
 	DestroyResponse struct{}

--- a/handler/destroy.go
+++ b/handler/destroy.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	liteEngineLogLimit = 2000 // max. number of lines for lite engine logs
+	liteEngineLogLimit = 10000 // max. number of lines for lite engine logs
 )
 
 func GetLiteEngineLog(liteEnginePath string) (string, error) {

--- a/handler/destroy.go
+++ b/handler/destroy.go
@@ -5,24 +5,94 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/harness/lite-engine/api"
 	"github.com/harness/lite-engine/engine"
 	"github.com/harness/lite-engine/logger"
+	"github.com/harness/lite-engine/logstream"
+	"github.com/harness/lite-engine/pipeline"
 )
+
+func GetLiteEngineLog(osType string) (string, error) {
+	switch osType {
+	// TODO: Add for windows and mac
+	case "linux":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", errors.New("could not fetch home dir")
+		}
+		path := filepath.Join(home, "lite-engine.log")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		return string(content), nil
+	default:
+		return "", errors.New("no log file")
+	}
+}
+
+func convert(logs string) []*logstream.Line {
+	lines := []*logstream.Line{}
+	for idx, line := range strings.Split(logs, "\n") {
+		lines = append(lines, &logstream.Line{Message: line, Number: idx})
+	}
+	return lines
+}
 
 // HandleDestroy returns an http.HandlerFunc that destroy the stage resources
 func HandleDestroy(engine *engine.Engine) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		st := time.Now()
 
-		if err := engine.Destroy(r.Context()); err != nil {
-			WriteError(w, err)
-		} else {
-			WriteJSON(w, api.DestroyResponse{}, http.StatusOK)
+		var uploadErr error
+		var logs string
+
+		// Upload lite engine logs if key is set
+		var d api.DestroyRequest
+		err := json.NewDecoder(r.Body).Decode(&d)
+		if err != nil {
+			WriteBadRequest(w, err)
+			return
 		}
+
+		if d.LogKey != "" {
+			if !d.LogDrone {
+				state := pipeline.GetState()
+				client := state.GetLogStreamClient()
+				logs, uploadErr = GetLiteEngineLog(runtime.GOOS)
+				if uploadErr != nil {
+					logger.FromRequest(r).WithField("time", time.Now().Format(time.RFC3339)).WithError(err).Errorln("could not fetch lite engine logs")
+				} else {
+					// error out if logs don't upload in a minute so that the VM can be destroyed
+					ctx, cancel := context.WithTimeout(r.Context(), 1*time.Minute)
+					defer cancel()
+					uploadErr = client.Upload(ctx, d.LogKey, convert(logs))
+					if uploadErr != nil {
+						logger.FromRequest(r).WithField("time", time.Now().Format(time.RFC3339)).WithError(err).Errorln("could not upload lite engine logs")
+					}
+				}
+			} else {
+				// TODO: handle drone case for lite engine log upload
+			}
+		}
+
+		destroyErr := engine.Destroy(r.Context())
+		if destroyErr != nil || uploadErr != nil {
+			WriteError(w, fmt.Errorf("destroy error: %w, upload error: %w", destroyErr, uploadErr))
+		}
+
+		WriteJSON(w, api.DestroyResponse{}, http.StatusOK)
 
 		logger.FromRequest(r).
 			WithField("latency", time.Since(st)).

--- a/livelog/livelog.go
+++ b/livelog/livelog.go
@@ -112,9 +112,10 @@ func (b *Writer) Write(p []byte) (n int, err error) {
 			Timestamp:   time.Now(),
 			ElaspedTime: int64(time.Since(b.now).Seconds()),
 		}
+		jsonLine, _ := json.Marshal(line)
 		logrus.WithField("name", b.name).Infoln(line.Message)
 
-		for b.size+len(part) > b.limit {
+		for b.size+len(jsonLine) > b.limit {
 			// Keep streaming even after the limit, but only upload last `b.limit` data to the store
 			if len(b.history) == 0 {
 				break
@@ -128,7 +129,7 @@ func (b *Writer) Write(p []byte) (n int, err error) {
 			b.history = b.history[1:]
 		}
 
-		b.size += len(part)
+		b.size = b.size + len(jsonLine)
 		b.num++
 
 		if !b.stopped() {

--- a/livelog/livelog_test.go
+++ b/livelog/livelog_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLineWriterSingle(t *testing.T) {
 	client := new(mockClient)
-	w := New(client, "1", "1", nil)
+	w := New(client, "1", "1", nil, false)
 	w.SetInterval(time.Duration(0))
 	w.num = 4
 	_, _ = w.Write([]byte("foo\nbar\n"))

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -257,7 +257,7 @@ func (e *StepExecutor) executeStep(r *api.StartStepRequest) (*runtime.State, map
 				defer cancel()
 			}
 			e.run(ctx, e.engine, r, wr) //nolint:errcheck
-			wc.Close()
+			wr.Close()
 		}()
 		return &runtime.State{Exited: false}, nil, nil, nil, nil
 	}
@@ -278,7 +278,7 @@ func (e *StepExecutor) executeStep(r *api.StartStepRequest) (*runtime.State, map
 
 	// close the stream. If the session is a remote session, the
 	// full log buffer is uploaded to the remote server.
-	if err = wc.Close(); err != nil {
+	if err = wr.Close(); err != nil {
 		result = multierror.Append(result, err)
 	}
 

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -242,7 +242,7 @@ func (e *StepExecutor) executeStep(r *api.StartStepRequest) (*runtime.State, map
 
 	// Create a log stream for step logs
 	client := state.GetLogStreamClient()
-	wc := livelog.New(client, r.LogKey, r.Name, getNudges())
+	wc := livelog.New(client, r.LogKey, r.Name, getNudges(), false)
 	wr := logstream.NewReplacer(wc, secrets)
 	go wr.Open() //nolint:errcheck
 


### PR DESCRIPTION
i) Adds lite engine log upload as part of the destroy call. We have seen many cases where debugging is difficult because of no lite engine logs. This will upload lite-engine.log  to help with debugging. 
ii) Fixes an issue where 5MB log limit was not being honored for VMs.