### PR TITLE
[CI-9246]: Do background execution for detach step only after pulling image

### DIFF
--- a/engine/docker/docker.go
+++ b/engine/docker/docker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/drone/runner-go/logger"
 	"github.com/drone/runner-go/pipeline/runtime"
 	"github.com/drone/runner-go/registry/auths"
+	"github.com/harness/lite-engine/logstream"
 )
 
 const (
@@ -183,24 +184,43 @@ func (e *Docker) Destroy(ctx context.Context, pipelineConfig *spec.PipelineConfi
 
 // Run runs the pipeline step.
 func (e *Docker) Run(ctx context.Context, pipelineConfig *spec.PipelineConfig, step *spec.Step,
-	output io.Writer) (*runtime.State, error) {
+	output io.Writer, isDrone bool) (*runtime.State, error) {
 	// create the container
 	err := e.create(ctx, pipelineConfig, step, output)
 	if err != nil {
 		return nil, errors.TrimExtraInfo(err)
 	}
+	if !isDrone && step.Detach {
+		go func() {
+			ctx_bg := context.Background()
+			var cancel context.CancelFunc
+			if deadline, ok := ctx.Deadline(); ok {
+				ctx_bg, cancel = context.WithTimeout(ctx_bg, time.Until(deadline))
+				defer cancel()
+			}
+			e.startContainer(ctx_bg, step.ID, output) //nolint:errcheck
+			if wr, ok := output.(logstream.Writer); ok {
+				wr.Close()
+			}
+		}()
+		return &runtime.State{Exited: false}, nil
+	}
+	return e.startContainer(ctx, step.ID, output)
+}
+
+func (e *Docker) startContainer(ctx context.Context, stepId string, output io.Writer) (*runtime.State, error) {
 	// start the container
-	err = e.start(ctx, step.ID)
+	err := e.start(ctx, stepId)
 	if err != nil {
 		return nil, errors.TrimExtraInfo(err)
 	}
 	// grab the logs from the container execution
-	err = e.logs(ctx, step.ID, output)
+	err = e.logs(ctx, stepId, output)
 	if err != nil {
 		return nil, errors.TrimExtraInfo(err)
 	}
 	// wait for the response
-	return e.waitRetry(ctx, step.ID)
+	return e.waitRetry(ctx, stepId)
 }
 
 //

--- a/engine/docker/docker.go
+++ b/engine/docker/docker.go
@@ -190,6 +190,7 @@ func (e *Docker) Run(ctx context.Context, pipelineConfig *spec.PipelineConfig, s
 	if err != nil {
 		return nil, errors.TrimExtraInfo(err)
 	}
+	// start the execution in go routine if it's a detach step and not drone
 	if !isDrone && step.Detach {
 		go func() {
 			ctxBg := context.Background()

--- a/engine/docker/docker.go
+++ b/engine/docker/docker.go
@@ -192,13 +192,13 @@ func (e *Docker) Run(ctx context.Context, pipelineConfig *spec.PipelineConfig, s
 	}
 	if !isDrone && step.Detach {
 		go func() {
-			ctx_bg := context.Background()
+			ctxBg := context.Background()
 			var cancel context.CancelFunc
 			if deadline, ok := ctx.Deadline(); ok {
-				ctx_bg, cancel = context.WithTimeout(ctx_bg, time.Until(deadline))
+				ctxBg, cancel = context.WithTimeout(ctxBg, time.Until(deadline))
 				defer cancel()
 			}
-			e.startContainer(ctx_bg, step.ID, output) //nolint:errcheck
+			e.startContainer(ctxBg, step.ID, output) //nolint:errcheck
 			if wr, ok := output.(logstream.Writer); ok {
 				wr.Close()
 			}
@@ -208,19 +208,19 @@ func (e *Docker) Run(ctx context.Context, pipelineConfig *spec.PipelineConfig, s
 	return e.startContainer(ctx, step.ID, output)
 }
 
-func (e *Docker) startContainer(ctx context.Context, stepId string, output io.Writer) (*runtime.State, error) {
+func (e *Docker) startContainer(ctx context.Context, stepID string, output io.Writer) (*runtime.State, error) {
 	// start the container
-	err := e.start(ctx, stepId)
+	err := e.start(ctx, stepID)
 	if err != nil {
 		return nil, errors.TrimExtraInfo(err)
 	}
 	// grab the logs from the container execution
-	err = e.logs(ctx, stepId, output)
+	err = e.logs(ctx, stepID, output)
 	if err != nil {
 		return nil, errors.TrimExtraInfo(err)
 	}
 	// wait for the response
-	return e.waitRetry(ctx, stepId)
+	return e.waitRetry(ctx, stepID)
 }
 
 //

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -127,7 +127,7 @@ func (e *Engine) Run(ctx context.Context, step *spec.Step, output io.Writer, isD
 		printCommand(step, output)
 	}
 	if step.Image != "" {
-		return e.docker.Run(ctx, cfg, step, output)
+		return e.docker.Run(ctx, cfg, step, output, isDrone)
 	}
 
 	return exec.Run(ctx, step, output)

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -248,6 +248,7 @@ func (e *StepExecutor) executeStep(r *api.StartStepRequest) (*runtime.State, map
 
 	// if the step is configured as a daemon, it is detached
 	// from the main process and executed separately.
+	// We do here only for non-container step.
 	if r.Detach && r.Image == "" {
 		go func() {
 			ctx := context.Background()

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -248,7 +248,7 @@ func (e *StepExecutor) executeStep(r *api.StartStepRequest) (*runtime.State, map
 
 	// if the step is configured as a daemon, it is detached
 	// from the main process and executed separately.
-	if r.Detach {
+	if r.Detach && r.Image == "" {
 		go func() {
 			ctx := context.Background()
 			var cancel context.CancelFunc
@@ -276,10 +276,13 @@ func (e *StepExecutor) executeStep(r *api.StartStepRequest) (*runtime.State, map
 		result = multierror.Append(result, err)
 	}
 
-	// close the stream. If the session is a remote session, the
-	// full log buffer is uploaded to the remote server.
-	if err = wr.Close(); err != nil {
-		result = multierror.Append(result, err)
+	// if err is not nill or it's not a detach step then always close the stream
+	if err != nil || !r.Detach {
+		// close the stream. If the session is a remote session, the
+		// full log buffer is uploaded to the remote server.
+		if err = wr.Close(); err != nil {
+			result = multierror.Append(result, err)
+		}
 	}
 
 	// if the context was canceled and returns a canceled or


### PR DESCRIPTION
Currently we are running the go routine for detach step before pulling the image for docker step. We have seen problems in some pipelines where due to image not being pulled the execution fails for different reasons. Here is one such example - https://harness.atlassian.net/browse/CI-9246. 

Have moved the go routine after pulling and creating the docker container.