### PR TITLE
Add support to update step status from LE directly

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -31,6 +31,7 @@ type (
 		LogDrone       bool   `json:"log_drone,omitempty"`
 		LogKey         string `json:"log_key,omitempty"`          // key to write the lite engine logs (optional)
 		LiteEnginePath string `json:"lite_engine_path,omitempty"` // where to find the lite engine logs
+		StageRuntimeID string `json:"stage_runtime_id,omitempty"`
 	}
 
 	DestroyResponse struct {
@@ -38,17 +39,18 @@ type (
 	}
 
 	StartStepRequest struct {
-		ID         string            `json:"id,omitempty"` // Unique identifier of step
-		Detach     bool              `json:"detach,omitempty"`
-		Envs       map[string]string `json:"environment,omitempty"`
-		Name       string            `json:"name,omitempty"`
-		LogKey     string            `json:"log_key,omitempty"`
-		LogDrone   bool              `json:"log_drone"`
-		Secrets    []string          `json:"secrets,omitempty"`
-		WorkingDir string            `json:"working_dir,omitempty"`
-		Kind       StepType          `json:"kind,omitempty"`
-		Run        RunConfig         `json:"run,omitempty"`
-		RunTest    RunTestConfig     `json:"run_test,omitempty"`
+		ID             string            `json:"id,omitempty"` // Unique identifier of step
+		StageRuntimeID string            `json:"stage_runtime_id,omitempty"`
+		Detach         bool              `json:"detach,omitempty"`
+		Envs           map[string]string `json:"environment,omitempty"`
+		Name           string            `json:"name,omitempty"`
+		LogKey         string            `json:"log_key,omitempty"`
+		LogDrone       bool              `json:"log_drone"`
+		Secrets        []string          `json:"secrets,omitempty"`
+		WorkingDir     string            `json:"working_dir,omitempty"`
+		Kind           StepType          `json:"kind,omitempty"`
+		Run            RunConfig         `json:"run,omitempty"`
+		RunTest        RunTestConfig     `json:"run_test,omitempty"`
 
 		OutputVars        []string   `json:"output_vars,omitempty"`
 		TestReport        TestReport `json:"test_report,omitempty"`

--- a/api/api.go
+++ b/api/api.go
@@ -167,12 +167,9 @@ type (
 
 	VMTaskExecutionResponse struct {
 		ErrorMessage           string                 `json:"error_message"`
-		IPAddress              string                 `json:"ip_address"`
 		OutputVars             map[string]string      `json:"output_vars"`
 		CommandExecutionStatus CommandExecutionStatus `json:"command_execution_status"`
 		Artifact               []byte                 `json:"artifact,omitempty"`
-		PoolDriverUsed         string                 `json:"pool_driver_used"`
-		DliteDistributed       bool                   `json:"dlite_distributed"`
 	}
 )
 

--- a/api/api.go
+++ b/api/api.go
@@ -166,9 +166,9 @@ type (
 	}
 
 	VMTaskExecutionResponse struct {
-		ErrorMessage           string                 `json:"error_message"`
-		OutputVars             map[string]string      `json:"output_vars"`
-		CommandExecutionStatus CommandExecutionStatus `json:"command_execution_status"`
+		ErrorMessage           string                 `json:"error_message,omitempty"`
+		OutputVars             map[string]string      `json:"output_vars,omitempty"`
+		CommandExecutionStatus CommandExecutionStatus `json:"command_execution_status,omitempty"`
 		Artifact               []byte                 `json:"artifact,omitempty"`
 	}
 )

--- a/api/api.go
+++ b/api/api.go
@@ -80,6 +80,7 @@ type (
 		User         string               `json:"user,omitempty"`
 		Volumes      []*spec.VolumeMount  `json:"volumes,omitempty"`
 		Files        []*spec.File         `json:"files,omitempty"`
+		StepStatus   StepStatusConfig     `json:"step_status,omitempty"`
 	}
 
 	StartStepResponse struct{}
@@ -155,4 +156,29 @@ type (
 	JunitReport struct {
 		Paths []string `json:"paths,omitempty"`
 	}
+
+	StepStatusConfig struct {
+		Endpoint   string `json:"endpoint,omitempty"`
+		Token      string `json:"token,omitempty"`
+		AccountID  string `json:"account_id,omitempty"`
+		DelegateID string `json:"delegate_id,omitempty"`
+		TaskID     string `json:"task_id,omitempty"`
+	}
+
+	VMTaskExecutionResponse struct {
+		ErrorMessage           string                 `json:"error_message"`
+		IPAddress              string                 `json:"ip_address"`
+		OutputVars             map[string]string      `json:"output_vars"`
+		CommandExecutionStatus CommandExecutionStatus `json:"command_execution_status"`
+		Artifact               []byte                 `json:"artifact,omitempty"`
+		PoolDriverUsed         string                 `json:"pool_driver_used"`
+		DliteDistributed       bool                   `json:"dlite_distributed"`
+	}
+)
+
+type CommandExecutionStatus string
+
+const (
+	Success CommandExecutionStatus = "SUCCESS"
+	Failure CommandExecutionStatus = "FAILURE"
 )

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 require (
 	github.com/dgryski/go-lttb v0.0.0-20230207170358-f8fc36cdbff1
 	github.com/shirou/gopsutil/v3 v3.23.5
-	github.com/wings-software/dlite v1.0.0-rc.7.0.20230906155942-0131cbbd1bee
+	github.com/wings-software/dlite v1.0.0-rc.8
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 require (
 	github.com/dgryski/go-lttb v0.0.0-20230207170358-f8fc36cdbff1
 	github.com/shirou/gopsutil/v3 v3.23.5
+	github.com/wings-software/dlite v1.0.0-rc.7.0.20230906155942-0131cbbd1bee
 )
 
 require (
@@ -56,6 +57,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect
@@ -67,6 +69,7 @@ require (
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
@@ -76,6 +79,7 @@ require (
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
+	golang.org/x/crypto v0.10.0 // indirect
 	golang.org/x/exp v0.0.0-20220927162542-c76eaa363f9d // indirect
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/net v0.11.0 // indirect
@@ -85,6 +89,7 @@ require (
 	google.golang.org/grpc v1.54.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/harness/ti-client v0.0.0-20230720204407-c0e24ffb7964 h1:XXOg2PARWL1s4lpy4WXPcWqt8fXfV9e9KjDozeefzdk=
@@ -124,6 +126,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b h1:YWuSjZCQAPM8UUBLkYUk1e+rZcvWHJmFb6i6rM44Xs8=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
 github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
@@ -167,6 +171,8 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/wings-software/dlite v1.0.0-rc.7.0.20230906155942-0131cbbd1bee h1:2b+6f0CyM3BkfHta0j6mI+HsRTAApSsAN0mA0JvVEKg=
+github.com/wings-software/dlite v1.0.0-rc.7.0.20230906155942-0131cbbd1bee/go.mod h1:zZd6iaMk8Av1QSABGuDWdxBFO82MxE0r6PRoDsLDvCE=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -178,6 +184,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
+golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
 golang.org/x/exp v0.0.0-20220927162542-c76eaa363f9d h1:3wgmvnqHUJ8SxiNWwea5NCzTwAVfhTtuV+0ClVFlClc=
 golang.org/x/exp v0.0.0-20220927162542-c76eaa363f9d/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -242,6 +250,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
+gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/wings-software/dlite v1.0.0-rc.7.0.20230906155942-0131cbbd1bee h1:2b+6f0CyM3BkfHta0j6mI+HsRTAApSsAN0mA0JvVEKg=
-github.com/wings-software/dlite v1.0.0-rc.7.0.20230906155942-0131cbbd1bee/go.mod h1:zZd6iaMk8Av1QSABGuDWdxBFO82MxE0r6PRoDsLDvCE=
+github.com/wings-software/dlite v1.0.0-rc.8 h1:Vsobn1Y09Vv0qh3oTqNHkJrbCYRvLeUGYsD3ewhr5e0=
+github.com/wings-software/dlite v1.0.0-rc.8/go.mod h1:zZd6iaMk8Av1QSABGuDWdxBFO82MxE0r6PRoDsLDvCE=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/handler/destroy.go
+++ b/handler/destroy.go
@@ -82,6 +82,9 @@ func HandleDestroy(engine *engine.Engine) http.HandlerFunc {
 							Format(time.RFC3339)).WithError(err).Errorln("could not upload lite engine logs")
 					}
 				}
+				if d.StageRuntimeID != "" {
+					pipeline.GetEnvState().Delete(d.StageRuntimeID)
+				}
 			}
 			// else {
 			// TODO: handle drone case for lite engine log upload

--- a/handler/step.go
+++ b/handler/step.go
@@ -37,7 +37,8 @@ func HandleStartStep(e *pruntime.StepExecutor) http.HandlerFunc {
 
 		s.Volumes = append(s.Volumes, getSharedVolumeMount())
 
-		if s.StepStatus.Token != "" {
+		// Stage runtime id will only flow when distributed dlite is enabled
+		if s.StageRuntimeID != "" {
 			err = e.StartStepWithStatusUpdate(r.Context(), &s)
 		} else {
 			err = e.StartStep(r.Context(), &s)

--- a/handler/step.go
+++ b/handler/step.go
@@ -37,7 +37,13 @@ func HandleStartStep(e *pruntime.StepExecutor) http.HandlerFunc {
 
 		s.Volumes = append(s.Volumes, getSharedVolumeMount())
 
-		if err := e.StartStep(r.Context(), &s); err != nil {
+		if s.StepStatus.Token != "" {
+			err = e.StartStepWithStatusUpdate(r.Context(), &s)
+		} else {
+			err = e.StartStep(r.Context(), &s)
+		}
+
+		if err != nil {
 			WriteError(w, err)
 		} else {
 			WriteJSON(w, api.StartStepResponse{}, http.StatusOK)

--- a/pipeline/env_state.go
+++ b/pipeline/env_state.go
@@ -1,0 +1,56 @@
+package pipeline
+
+import (
+	"sync"
+)
+
+var (
+	envState *EnvState
+	o        sync.Once
+)
+
+// EnvState stores the exported env variables by a step in a stage.
+type EnvState struct {
+	mu  sync.Mutex
+	env map[string]map[string]string
+}
+
+func (s *EnvState) Get(stageRuntimeID string) map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	val, ok := s.env[stageRuntimeID]
+	if ok {
+		return val
+	}
+	return nil
+}
+
+func (s *EnvState) Add(stageRuntimeID string, envs map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.env[stageRuntimeID]; !ok {
+		s.env[stageRuntimeID] = make(map[string]string)
+	}
+	for k, v := range envs {
+		s.env[stageRuntimeID][k] = v
+	}
+}
+
+func (s *EnvState) Delete(stageRuntimeID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.env, stageRuntimeID)
+}
+
+func GetEnvState() *EnvState {
+	o.Do(func() {
+		envState = &EnvState{
+			mu:  sync.Mutex{},
+			env: make(map[string]map[string]string),
+		}
+	})
+	return envState
+}

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -42,7 +42,7 @@ const (
 	NotStarted ExecutionStatus = iota
 	Running
 	Complete
-	defaultStepTimeout = 10 * time.Second // default step timeout
+	defaultStepTimeout = 10 * time.Hour // default step timeout
 )
 
 type StepExecutor struct {

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -384,7 +384,7 @@ func (e *StepExecutor) sendStepStatus(r *api.StartStepRequest, response *api.VMT
 		Type: stepStatusUpdate,
 	}
 	if err = delegateClient.SendStatus(context.Background(), r.StepStatus.DelegateID, r.StepStatus.TaskID, taskResponse); err != nil {
-		logrus.WithField("id", r.ID).Errorln("failed to send step status: ", err)
+		logrus.WithField("id", r.ID).WithError(err).Errorln("failed to send step status")
 		return
 	}
 	logrus.WithField("id", r.ID).Infoln("successfully sent step status")

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -359,7 +359,7 @@ func (e *StepExecutor) sendStepStatus(r *api.StartStepRequest, response *api.VMT
 	taskResponse := &client.TaskResponse{
 		Data: json.RawMessage(jsonData),
 		Code: "OK",
-		Type: "CI_LE_STATUS",
+		Type: "DLITE_CI_VM_EXECUTE_TASK",
 	}
 	if err = delegateClient.SendStatus(context.Background(), r.StepStatus.DelegateID, r.StepStatus.TaskID, taskResponse); err != nil {
 		logrus.WithField("id", r.ID).Errorln("failed to send step status: ", err)

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -43,6 +43,7 @@ const (
 	Running
 	Complete
 	defaultStepTimeout = 10 * time.Hour // default step timeout
+	stepStatusUpdate   = "DLITE_CI_VM_EXECUTE_TASK"
 )
 
 type StepExecutor struct {
@@ -361,7 +362,7 @@ func (e *StepExecutor) sendStepStatus(r *api.StartStepRequest, response *api.VMT
 	taskResponse := &client.TaskResponse{
 		Data: json.RawMessage(jsonData),
 		Code: "OK",
-		Type: "DLITE_CI_VM_EXECUTE_TASK",
+		Type: stepStatusUpdate,
 	}
 	if err = delegateClient.SendStatus(context.Background(), r.StepStatus.DelegateID, r.StepStatus.TaskID, taskResponse); err != nil {
 		logrus.WithField("id", r.ID).Errorln("failed to send step status: ", err)

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -99,23 +99,23 @@ func (e *StepExecutor) StartStepWithStatusUpdate(ctx context.Context, r *api.Sta
 	}
 
 	go func() {
-		timeoutCtx, cancel := context.WithTimeout(ctx, defaultStepTimeout)
-		defer cancel()
+		done := make(chan api.VMTaskExecutionResponse, 1)
 
 		var resp api.VMTaskExecutionResponse
-
-		select {
-		case <-timeoutCtx.Done():
-			resp = api.VMTaskExecutionResponse{CommandExecutionStatus: api.Failure, ErrorMessage: timeoutCtx.Err().Error()}
-			e.sendStepStatus(r, &resp)
-			return
-		default:
-		}
-
 		state, outputs, envs, artifact, stepErr := e.executeStep(r)
 		status := StepStatus{Status: Complete, State: state, StepErr: stepErr, Outputs: outputs, Envs: envs, Artifact: artifact}
 		resp = convertPollResponse(convertStatus(status))
-		e.sendStepStatus(r, &resp)
+		done <- resp
+
+		select {
+		case resp = <-done:
+			e.sendStepStatus(r, &resp)
+			return
+		case <-time.After(defaultStepTimeout):
+			resp = api.VMTaskExecutionResponse{CommandExecutionStatus: api.Failure, ErrorMessage: "step timed out"}
+			e.sendStepStatus(r, &resp)
+			return
+		}
 	}()
 	return nil
 }

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -385,7 +385,9 @@ func (e *StepExecutor) sendStepStatus(r *api.StartStepRequest, response *api.VMT
 	}
 	if err = delegateClient.SendStatus(context.Background(), r.StepStatus.DelegateID, r.StepStatus.TaskID, taskResponse); err != nil {
 		logrus.WithField("id", r.ID).Errorln("failed to send step status: ", err)
+		return
 	}
+	logrus.WithField("id", r.ID).Infoln("successfully sent step status")
 }
 
 func convertStatus(status StepStatus) *api.PollStepResponse {

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -100,12 +100,7 @@ func (e *StepExecutor) StartStepWithStatusUpdate(ctx context.Context, r *api.Sta
 
 	go func() {
 		done := make(chan api.VMTaskExecutionResponse, 1)
-
 		var resp api.VMTaskExecutionResponse
-		state, outputs, envs, artifact, stepErr := e.executeStep(r)
-		status := StepStatus{Status: Complete, State: state, StepErr: stepErr, Outputs: outputs, Envs: envs, Artifact: artifact}
-		resp = convertPollResponse(convertStatus(status))
-		done <- resp
 
 		select {
 		case resp = <-done:
@@ -115,7 +110,13 @@ func (e *StepExecutor) StartStepWithStatusUpdate(ctx context.Context, r *api.Sta
 			resp = api.VMTaskExecutionResponse{CommandExecutionStatus: api.Failure, ErrorMessage: "step timed out"}
 			e.sendStepStatus(r, &resp)
 			return
+		default:
 		}
+
+		state, outputs, envs, artifact, stepErr := e.executeStep(r)
+		status := StepStatus{Status: Complete, State: state, StepErr: stepErr, Outputs: outputs, Envs: envs, Artifact: artifact}
+		resp = convertPollResponse(convertStatus(status))
+		done <- resp
 	}()
 	return nil
 }

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -42,7 +42,7 @@ const (
 	NotStarted ExecutionStatus = iota
 	Running
 	Complete
-	defaultStepTimeout = 10 * time.Hour // default step timeout
+	defaultStepTimeout = 10 * time.Second // default step timeout
 )
 
 type StepExecutor struct {

--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -107,7 +107,7 @@ func (e *StepExecutor) StartStepWithStatusUpdate(ctx context.Context, r *api.Sta
 		select {
 		case <-timeoutCtx.Done():
 			resp = api.VMTaskExecutionResponse{CommandExecutionStatus: api.Failure, ErrorMessage: timeoutCtx.Err().Error()}
-			e.sendStepStatus(r, resp)
+			e.sendStepStatus(r, &resp)
 			return
 		default:
 		}
@@ -115,7 +115,7 @@ func (e *StepExecutor) StartStepWithStatusUpdate(ctx context.Context, r *api.Sta
 		state, outputs, envs, artifact, stepErr := e.executeStep(r)
 		status := StepStatus{Status: Complete, State: state, StepErr: stepErr, Outputs: outputs, Envs: envs, Artifact: artifact}
 		resp = convertPollResponse(convertStatus(status))
-		e.sendStepStatus(r, resp)
+		e.sendStepStatus(r, &resp)
 	}()
 	return nil
 }
@@ -349,7 +349,7 @@ func (e *StepExecutor) run(ctx context.Context, engine *engine.Engine, r *api.St
 	return executeRunTestStep(ctx, engine, r, out, tiConfig)
 }
 
-func (e *StepExecutor) sendStepStatus(r *api.StartStepRequest, response api.VMTaskExecutionResponse) {
+func (e *StepExecutor) sendStepStatus(r *api.StartStepRequest, response *api.VMTaskExecutionResponse) {
 	jsonData, err := json.Marshal(response)
 	if err != nil {
 		logrus.WithField("id", r.ID).Errorln("Error marshaling struct:", err)


### PR DESCRIPTION
This change add support to do step status directly from LE to manager.
Added change to store prev step envs which are required for github action plugins. This same logic is used in dlite runner.