### PR TITLE
Use default values for python and ruby test generation

### DIFF
--- a/pipeline/runtime/runtest.go
+++ b/pipeline/runtime/runtest.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/drone/runner-go/pipeline/runtime"
@@ -94,12 +92,6 @@ func collectRunTestData(ctx context.Context, log *logrus.Logger, r *api.StartSte
 	}
 
 	reportStart := time.Now()
-	switch strings.ToLower(r.RunTest.Language) {
-	case "python", "ruby":
-		if len(r.TestReport.Junit.Paths) == 0 {
-			r.TestReport.Junit.Paths = []string{filepath.Join(r.WorkingDir, "harness_test_results.xml")}
-		}
-	}
 	crErr := collectTestReportsFn(ctx, r.TestReport, r.WorkingDir, stepName, r.RunTest.Language, log, reportStart, tiConfig)
 	if crErr != nil {
 		log.WithField("error", crErr).Errorln(fmt.Sprintf("Failed to upload report. Time taken: %s", time.Since(reportStart)))

--- a/pipeline/runtime/runtest.go
+++ b/pipeline/runtime/runtest.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	collectCgFn          = callgraph.Upload
-	collectTestReportsFn = report.ParseAndUploadTestsWithLanguage
+	collectTestReportsFn = report.ParseAndUploadTestsForLanguage
 )
 
 func executeRunTestStep(ctx context.Context, engine *engine.Engine, r *api.StartStepRequest, out io.Writer, tiConfig *tiCfg.Cfg) ( //nolint:gocritic

--- a/pipeline/runtime/runtest_test.go
+++ b/pipeline/runtime/runtest_test.go
@@ -58,7 +58,7 @@ func Test_CollectRunTestData(t *testing.T) {
 			collectCgFn = func(ctx context.Context, stepID string, timeMs int64, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
 				return tc.cgErr
 			}
-			collectTestReportsFn = func(ctx context.Context, report api.TestReport, workDir, stepID string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
+			collectTestReportsFn = func(ctx context.Context, report api.TestReport, workDir, stepID, language string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
 				return tc.crErr
 			}
 			err := collectRunTestData(ctx, log, &apiReq, time.Now(), stepName, &tiConfig)

--- a/ti/instrumentation/python/pytest.go
+++ b/ti/instrumentation/python/pytest.go
@@ -54,6 +54,10 @@ func (m *pytestRunner) ReadPackages(workspace string, files []ti.File) []ti.File
 
 func (m *pytestRunner) GetCmd(ctx context.Context, tests []ti.RunnableTest, userArgs, workspace,
 	agentConfigPath, agentInstallDir string, ignoreInstr, runAll bool) (string, error) {
+	if userArgs == "" {
+		userArgs = "--junitxml=harness_test_results.xml -o junit_family='xunit1'"
+	}
+
 	scriptPath, testHarness, err := UnzipAndGetTestInfo(agentInstallDir, ignoreInstr, pytestCmd, userArgs, m.log)
 	if err != nil {
 		return "", err

--- a/ti/instrumentation/python/unittest.go
+++ b/ti/instrumentation/python/unittest.go
@@ -51,6 +51,9 @@ func (m *unittestRunner) ReadPackages(workspace string, files []ti.File) []ti.Fi
 
 func (m *unittestRunner) GetCmd(ctx context.Context, tests []ti.RunnableTest, userArgs, workspace,
 	agentConfigPath, agentInstallDir string, ignoreInstr, runAll bool) (string, error) {
+	if userArgs == "" {
+		userArgs = "--junitxml=harness_test_results.xml -o junit_family='xunit1'"
+	}
 	// Run all the tests
 	scriptPath, testHarness, err := UnzipAndGetTestInfo(agentInstallDir, ignoreInstr, unitTestCmd, userArgs, m.log)
 	if err != nil {

--- a/ti/instrumentation/ruby/rspec.go
+++ b/ti/instrumentation/ruby/rspec.go
@@ -68,7 +68,7 @@ func (m *rspecRunner) GetCmd(ctx context.Context, tests []ti.RunnableTest, userA
 	}
 	// Run all the tests
 	if userArgs == "" {
-		userArgs = "--out harness_test_results.xml"
+		userArgs = "--format RspecJunitFormatter --out harness_test_results.xml"
 	}
 
 	if runAll {

--- a/ti/instrumentation/ruby/rspec.go
+++ b/ti/instrumentation/ruby/rspec.go
@@ -67,6 +67,10 @@ func (m *rspecRunner) GetCmd(ctx context.Context, tests []ti.RunnableTest, userA
 		}
 	}
 	// Run all the tests
+	if userArgs == "" {
+		userArgs = "--out harness_test_results.xml"
+	}
+
 	if runAll {
 		if ignoreInstr {
 			return strings.TrimSpace(fmt.Sprintf("%s %s", rspecCmd, userArgs)), nil

--- a/ti/report/report.go
+++ b/ti/report/report.go
@@ -18,12 +18,27 @@ import (
 )
 
 func ParseAndUploadTests(ctx context.Context, report api.TestReport, workDir, stepID string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
-	if report.Kind != api.Junit {
-		return fmt.Errorf("unknown report type: %s", report.Kind)
-	}
+	return ParseAndUploadTestsForLanguage(ctx, report, workDir, stepID, "", log, start, tiConfig)
+}
 
-	if len(report.Junit.Paths) == 0 {
-		return nil
+func ParseAndUploadTestsForLanguage(ctx context.Context, report api.TestReport, workDir, stepID, language string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
+	switch strings.ToLower(language) {
+	case "python", "ruby":
+		if len(report.Junit.Paths) == 0 {
+			report.Junit.Paths = []string{"harness_test_results.xml*"}
+		} else {
+			if report.Kind != api.Junit {
+				return fmt.Errorf("unknown report type: %s", report.Kind)
+			}
+		}
+	default:
+		if report.Kind != api.Junit {
+			return fmt.Errorf("unknown report type: %s", report.Kind)
+		}
+
+		if len(report.Junit.Paths) == 0 {
+			return nil
+		}
 	}
 
 	// Append working dir to the paths. In k8s, we specify the workDir in the YAML but this is

--- a/ti/report/report.go
+++ b/ti/report/report.go
@@ -26,10 +26,8 @@ func ParseAndUploadTestsForLanguage(ctx context.Context, report api.TestReport, 
 	case "python", "ruby":
 		if len(report.Junit.Paths) == 0 {
 			report.Junit.Paths = []string{"harness_test_results.xml*"}
-		} else {
-			if report.Kind != api.Junit {
-				return fmt.Errorf("unknown report type: %s", report.Kind)
-			}
+		} else if report.Kind != api.Junit {
+			return fmt.Errorf("unknown report type: %s", report.Kind)
 		}
 	default:
 		if report.Kind != api.Junit {


### PR DESCRIPTION
- added output command to rspec and python runners if user does not provided the command
- added default path to python and ruby if not exist