### PR TITLE
[feat]: [CI-9899]: Parse filename in cypress juint xml

### DIFF
--- a/pipeline/runtime/run.go
+++ b/pipeline/runtime/run.go
@@ -53,7 +53,7 @@ func executeRunStep(ctx context.Context, engine *engine.Engine, r *api.StartStep
 	exited, err := engine.Run(ctx, step, out, r.LogDrone)
 
 	reportStart := time.Now()
-	if rerr := report.ParseAndUploadTests(ctx, r.TestReport, r.WorkingDir, step.Name, log, reportStart, tiConfig); rerr != nil {
+	if rerr := report.ParseAndUploadTests(ctx, r.TestReport, r.WorkingDir, step.Name, log, reportStart, tiConfig, r.Envs); rerr != nil {
 		logrus.WithError(rerr).WithField("step", step.Name).Errorln("failed to upload report")
 		log.Errorf("Failed to upload report. Time taken: %s", time.Since(reportStart))
 	}

--- a/pipeline/runtime/runtest.go
+++ b/pipeline/runtime/runtest.go
@@ -93,7 +93,7 @@ func collectRunTestData(ctx context.Context, log *logrus.Logger, r *api.StartSte
 	}
 
 	reportStart := time.Now()
-	crErr := collectTestReportsFn(ctx, r.TestReport, r.WorkingDir, stepName, log, reportStart, tiConfig)
+	crErr := collectTestReportsFn(ctx, r.TestReport, r.WorkingDir, stepName, log, reportStart, tiConfig, r.Envs)
 	if crErr != nil {
 		log.WithField("error", crErr).Errorln(fmt.Sprintf("Failed to upload report. Time taken: %s", time.Since(reportStart)))
 	}

--- a/pipeline/runtime/runtest_test.go
+++ b/pipeline/runtime/runtest_test.go
@@ -58,7 +58,7 @@ func Test_CollectRunTestData(t *testing.T) {
 			collectCgFn = func(ctx context.Context, stepID string, timeMs int64, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
 				return tc.cgErr
 			}
-			collectTestReportsFn = func(ctx context.Context, report api.TestReport, workDir, stepID string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
+			collectTestReportsFn = func(ctx context.Context, report api.TestReport, workDir, stepID string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg, envs map[string]string) error {
 				return tc.crErr
 			}
 			err := collectRunTestData(ctx, log, &apiReq, time.Now(), stepName, &tiConfig)

--- a/ti/report/parser/junit/gojunit/ingest.go
+++ b/ti/report/parser/junit/gojunit/ingest.go
@@ -49,15 +49,15 @@ func ingestSuite(root xmlNode, parentFilename string) Suite { //nolint:gocritic
 		Properties: root.Attrs,
 	}
 
-	file := getFilename(root.Attr("file"), parentFilename)
+	parentFilename = getFilename(root.Attr("file"), parentFilename)
 
 	for _, node := range root.Nodes {
 		switch node.XMLName.Local {
 		case "testsuite":
-			testsuite := ingestSuite(node, file)
+			testsuite := ingestSuite(node, parentFilename)
 			suite.Suites = append(suite.Suites, testsuite)
 		case "testcase":
-			testcase := ingestTestcase(node, file)
+			testcase := ingestTestcase(node, parentFilename)
 			suite.Tests = append(suite.Tests, testcase)
 		case "properties":
 			props := ingestProperties(node)

--- a/ti/report/parser/junit/gojunit/ingest.go
+++ b/ti/report/parser/junit/gojunit/ingest.go
@@ -16,20 +16,28 @@ import (
 	ti "github.com/harness/ti-client/types"
 )
 
-const cypressRootSuiteName = "Root Suite"
+const defaultRootSuiteName = "Root Suite"
+
+func getRootSuiteName(envs map[string]string) string {
+	if val, ok := envs["HARNESS_JUNIT_ROOT_SUITE_NAME"]; ok {
+		return val
+	}
+	return defaultRootSuiteName
+}
 
 // findSuites performs a depth-first search through the XML document, and
 // attempts to ingest any "testsuite" tags that are encountered.
-func findSuites(nodes []xmlNode, suites chan Suite, parentFilename string) {
+func findSuites(nodes []xmlNode, suites chan Suite, parentFilename string, envs map[string]string) {
+	rootSuiteName := getRootSuiteName(envs)
 	for _, node := range nodes {
 		switch node.XMLName.Local {
 		case "testsuite":
 			suites <- ingestSuite(node, parentFilename)
-			if node.Attr("name") == cypressRootSuiteName {
+			if node.Attr("name") == rootSuiteName {
 				parentFilename = node.Attr("file")
 			}
 		default:
-			findSuites(node.Nodes, suites, parentFilename)
+			findSuites(node.Nodes, suites, parentFilename, envs)
 		}
 	}
 }

--- a/ti/report/parser/junit/gojunit/ingest.go
+++ b/ti/report/parser/junit/gojunit/ingest.go
@@ -16,33 +16,40 @@ import (
 	ti "github.com/harness/ti-client/types"
 )
 
+const cypressRootSuiteName = "Root Suite"
+
 // findSuites performs a depth-first search through the XML document, and
 // attempts to ingest any "testsuite" tags that are encountered.
-func findSuites(nodes []xmlNode, suites chan Suite) {
+func findSuites(nodes []xmlNode, suites chan Suite, parentFilename string) {
 	for _, node := range nodes {
 		switch node.XMLName.Local {
 		case "testsuite":
-			suites <- ingestSuite(node)
+			suites <- ingestSuite(node, parentFilename)
+			if node.Attr("name") == cypressRootSuiteName {
+				parentFilename = node.Attr("file")
+			}
 		default:
-			findSuites(node.Nodes, suites)
+			findSuites(node.Nodes, suites, parentFilename)
 		}
 	}
 }
 
-func ingestSuite(root xmlNode) Suite { //nolint:gocritic
+func ingestSuite(root xmlNode, parentFilename string) Suite { //nolint:gocritic
 	suite := Suite{
 		Name:       root.Attr("name"),
 		Package:    root.Attr("package"),
 		Properties: root.Attrs,
 	}
 
+	file := getFilename(root.Attr("file"), parentFilename)
+
 	for _, node := range root.Nodes {
 		switch node.XMLName.Local {
 		case "testsuite":
-			testsuite := ingestSuite(node)
+			testsuite := ingestSuite(node, file)
 			suite.Suites = append(suite.Suites, testsuite)
 		case "testcase":
-			testcase := ingestTestcase(node)
+			testcase := ingestTestcase(node, file)
 			suite.Tests = append(suite.Tests, testcase)
 		case "properties":
 			props := ingestProperties(node)
@@ -72,11 +79,11 @@ func ingestProperties(root xmlNode) map[string]string { //nolint:gocritic
 	return props
 }
 
-func ingestTestcase(root xmlNode) Test { //nolint:gocritic
+func ingestTestcase(root xmlNode, parentFilename string) Test { //nolint:gocritic
 	test := Test{
 		Name:       root.Attr("name"),
 		Classname:  root.Attr("classname"),
-		Filename:   root.Attr("file"),
+		Filename:   getFilename(root.Attr("file"), parentFilename),
 		DurationMs: duration(root.Attr("time")).Milliseconds(),
 		Result:     ti.Result{Status: ti.StatusPassed},
 		Properties: root.Attrs,
@@ -123,4 +130,12 @@ func duration(t string) time.Duration {
 	}
 
 	return 0
+}
+
+// getFilename returns the filename, using the parent filename if the current filename is empty
+func getFilename(currentFilename, parentFilename string) string {
+	if currentFilename != "" {
+		return currentFilename
+	}
+	return parentFilename
 }

--- a/ti/report/parser/junit/gojunit/ingest.go
+++ b/ti/report/parser/junit/gojunit/ingest.go
@@ -16,19 +16,9 @@ import (
 	ti "github.com/harness/ti-client/types"
 )
 
-const defaultRootSuiteName = "Root Suite"
-
-func getRootSuiteName(envs map[string]string) string {
-	if val, ok := envs["HARNESS_JUNIT_ROOT_SUITE_NAME"]; ok {
-		return val
-	}
-	return defaultRootSuiteName
-}
-
 // findSuites performs a depth-first search through the XML document, and
 // attempts to ingest any "testsuite" tags that are encountered.
-func findSuites(nodes []xmlNode, suites chan Suite, parentFilename string, envs map[string]string) {
-	rootSuiteName := getRootSuiteName(envs)
+func findSuites(nodes []xmlNode, suites chan Suite, parentFilename, rootSuiteName string) {
 	for _, node := range nodes {
 		switch node.XMLName.Local {
 		case "testsuite":
@@ -37,7 +27,7 @@ func findSuites(nodes []xmlNode, suites chan Suite, parentFilename string, envs 
 				parentFilename = node.Attr("file")
 			}
 		default:
-			findSuites(node.Nodes, suites, parentFilename, envs)
+			findSuites(node.Nodes, suites, parentFilename, rootSuiteName)
 		}
 	}
 }

--- a/ti/report/parser/junit/gojunit/ingest_test.go
+++ b/ti/report/parser/junit/gojunit/ingest_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestExamplesInTheWild(t *testing.T) { //nolint:funlen
-	envs := make(map[string]string)
 	tests := []struct {
 		title    string
 		filename string
@@ -256,7 +255,7 @@ func TestExamplesInTheWild(t *testing.T) { //nolint:funlen
 		name := fmt.Sprintf("#%d - %s", index+1, test.title)
 
 		t.Run(name, func(t *testing.T) {
-			suites, err := IngestFile(test.filename, envs)
+			suites, err := IngestFile(test.filename, "Root Suite")
 			require.NoError(t, err)
 			test.check(t, suites)
 		})
@@ -264,8 +263,6 @@ func TestExamplesInTheWild(t *testing.T) { //nolint:funlen
 }
 
 func TestCustomRootSuite(t *testing.T) {
-	envs := make(map[string]string)
-	envs["HARNESS_JUNIT_ROOT_SUITE_NAME"] = "Custom Root Suite"
 	tests := []struct {
 		title    string
 		filename string
@@ -304,7 +301,7 @@ func TestCustomRootSuite(t *testing.T) {
 		name := fmt.Sprintf("#%d - %s", index+1, test.title)
 
 		t.Run(name, func(t *testing.T) {
-			suites, err := IngestFile(test.filename, envs)
+			suites, err := IngestFile(test.filename, "Custom Root Suite")
 			require.NoError(t, err)
 			test.check(t, suites)
 		})

--- a/ti/report/parser/junit/gojunit/ingest_test.go
+++ b/ti/report/parser/junit/gojunit/ingest_test.go
@@ -263,7 +263,7 @@ func TestExamplesInTheWild(t *testing.T) { //nolint:funlen
 	}
 }
 
-func TestCustomRootSuite(t *testing.T) { //nolint:funlen
+func TestCustomRootSuite(t *testing.T) {
 	envs := make(map[string]string)
 	envs["HARNESS_JUNIT_ROOT_SUITE_NAME"] = "Custom Root Suite"
 	tests := []struct {

--- a/ti/report/parser/junit/gojunit/ingest_test.go
+++ b/ti/report/parser/junit/gojunit/ingest_test.go
@@ -223,6 +223,32 @@ func TestExamplesInTheWild(t *testing.T) { //nolint:funlen
 				assert.Equal(t, expectedTotals, actualTotals)
 			},
 		},
+		{
+			title:    "cypress example",
+			filename: "testdata/cypress.xml",
+			check: func(t *testing.T, suites []Suite) {
+				assert.Len(t, suites, 5)
+				assert.Len(t, suites[0].Tests, 0)
+				assert.Len(t, suites[2].Tests, 3)
+
+				var testcase = Test{
+					Name:       "RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit form with empty required fields validations",
+					Classname:  "Submit form with empty required fields validations",
+					Filename:   "integration/70-pipeline/RunPipelineJiraApprovalStage.spec.ts",
+					DurationMs: 22701,
+					Result: ti.Result{
+						Status: ti.StatusPassed,
+					},
+					Properties: map[string]string{
+						"classname": "Submit form with empty required fields validations",
+						"name":      "RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit form with empty required fields validations",
+						"time":      "22.701",
+					},
+				}
+
+				assert.Equal(t, testcase, suites[2].Tests[1])
+			},
+		},
 	}
 
 	for index, test := range tests {

--- a/ti/report/parser/junit/gojunit/ingesters.go
+++ b/ti/report/parser/junit/gojunit/ingesters.go
@@ -14,30 +14,21 @@ import (
 	"os"
 )
 
-const defaultRootSuiteName = "Root Suite"
-
-func getRootSuiteName(envs map[string]string) string {
-	if val, ok := envs["HARNESS_JUNIT_ROOT_SUITE_NAME"]; ok {
-		return val
-	}
-	return defaultRootSuiteName
-}
-
 // IngestFile will parse the given XML file and return a slice of all contained
 // JUnit test suite definitions.
-func IngestFile(filename string, envs map[string]string) ([]Suite, error) {
+func IngestFile(filename string, rootSuiteName string) ([]Suite, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
-	return IngestReader(file, envs)
+	return IngestReader(file, rootSuiteName)
 }
 
 // IngestReader will parse the given XML reader and return a slice of all
 // contained JUnit test suite definitions.
-func IngestReader(reader io.Reader, envs map[string]string) ([]Suite, error) {
+func IngestReader(reader io.Reader, rootSuiteName string) ([]Suite, error) {
 	var (
 		suiteChan = make(chan Suite)
 		suites    = make([]Suite, 0)
@@ -49,7 +40,7 @@ func IngestReader(reader io.Reader, envs map[string]string) ([]Suite, error) {
 	}
 
 	go func() {
-		findSuites(nodes, suiteChan, "", getRootSuiteName(envs))
+		findSuites(nodes, suiteChan, "", rootSuiteName)
 		close(suiteChan)
 	}()
 
@@ -62,6 +53,6 @@ func IngestReader(reader io.Reader, envs map[string]string) ([]Suite, error) {
 
 // Ingest will parse the given XML data and return a slice of all contained
 // JUnit test suite definitions.
-func Ingest(data []byte, envs map[string]string) ([]Suite, error) {
-	return IngestReader(bytes.NewReader(data), envs)
+func Ingest(data []byte, rootSuiteName string) ([]Suite, error) {
+	return IngestReader(bytes.NewReader(data), rootSuiteName)
 }

--- a/ti/report/parser/junit/gojunit/ingesters.go
+++ b/ti/report/parser/junit/gojunit/ingesters.go
@@ -16,19 +16,19 @@ import (
 
 // IngestFile will parse the given XML file and return a slice of all contained
 // JUnit test suite definitions.
-func IngestFile(filename string) ([]Suite, error) {
+func IngestFile(filename string, envs map[string]string) ([]Suite, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
-	return IngestReader(file)
+	return IngestReader(file, envs)
 }
 
 // IngestReader will parse the given XML reader and return a slice of all
 // contained JUnit test suite definitions.
-func IngestReader(reader io.Reader) ([]Suite, error) {
+func IngestReader(reader io.Reader, envs map[string]string) ([]Suite, error) {
 	var (
 		suiteChan = make(chan Suite)
 		suites    = make([]Suite, 0)
@@ -40,7 +40,7 @@ func IngestReader(reader io.Reader) ([]Suite, error) {
 	}
 
 	go func() {
-		findSuites(nodes, suiteChan, "")
+		findSuites(nodes, suiteChan, "", envs)
 		close(suiteChan)
 	}()
 
@@ -53,6 +53,6 @@ func IngestReader(reader io.Reader) ([]Suite, error) {
 
 // Ingest will parse the given XML data and return a slice of all contained
 // JUnit test suite definitions.
-func Ingest(data []byte) ([]Suite, error) {
-	return IngestReader(bytes.NewReader(data))
+func Ingest(data []byte, envs map[string]string) ([]Suite, error) {
+	return IngestReader(bytes.NewReader(data), envs)
 }

--- a/ti/report/parser/junit/gojunit/ingesters.go
+++ b/ti/report/parser/junit/gojunit/ingesters.go
@@ -16,7 +16,7 @@ import (
 
 // IngestFile will parse the given XML file and return a slice of all contained
 // JUnit test suite definitions.
-func IngestFile(filename string, rootSuiteName string) ([]Suite, error) {
+func IngestFile(filename, rootSuiteName string) ([]Suite, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err

--- a/ti/report/parser/junit/gojunit/ingesters.go
+++ b/ti/report/parser/junit/gojunit/ingesters.go
@@ -14,6 +14,15 @@ import (
 	"os"
 )
 
+const defaultRootSuiteName = "Root Suite"
+
+func getRootSuiteName(envs map[string]string) string {
+	if val, ok := envs["HARNESS_JUNIT_ROOT_SUITE_NAME"]; ok {
+		return val
+	}
+	return defaultRootSuiteName
+}
+
 // IngestFile will parse the given XML file and return a slice of all contained
 // JUnit test suite definitions.
 func IngestFile(filename string, envs map[string]string) ([]Suite, error) {
@@ -40,7 +49,7 @@ func IngestReader(reader io.Reader, envs map[string]string) ([]Suite, error) {
 	}
 
 	go func() {
-		findSuites(nodes, suiteChan, "", envs)
+		findSuites(nodes, suiteChan, "", getRootSuiteName(envs))
 		close(suiteChan)
 	}()
 

--- a/ti/report/parser/junit/gojunit/ingesters.go
+++ b/ti/report/parser/junit/gojunit/ingesters.go
@@ -40,7 +40,7 @@ func IngestReader(reader io.Reader) ([]Suite, error) {
 	}
 
 	go func() {
-		findSuites(nodes, suiteChan)
+		findSuites(nodes, suiteChan, "")
 		close(suiteChan)
 	}()
 

--- a/ti/report/parser/junit/gojunit/testdata/cypress-custom.xml
+++ b/ti/report/parser/junit/gojunit/testdata/cypress-custom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="147.803" tests="8" failures="0">
+  <testsuite name="Custom Root Suite" timestamp="2023-11-15T18:28:15" tests="0" file="integration/70-pipeline/RunPipelineJiraApprovalStage.spec.ts" time="0.000" failures="0">
+  </testsuite>
+  <testsuite name="RUN PIPELINE MODAL - Jira Approval Stage" timestamp="2023-11-15T18:28:15" tests="1" time="0.000" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage should display the delete pipeline stage modal" time="13.856" classname="should display the delete pipeline stage modal">
+    </testcase>
+  </testsuite>
+  <testsuite name="Jira Create Form Test" timestamp="2023-11-15T18:28:29" tests="3" time="62.737" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit empty form Validations" time="15.354" classname="Submit empty form Validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit form with empty required fields validations" time="22.701" classname="Submit form with empty required fields validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit form after filling details" time="24.647" classname="Submit form after filling details">
+    </testcase>
+  </testsuite>
+  <testsuite name="Jira Approval Form Test" timestamp="2023-11-15T18:29:32" tests="2" time="36.923" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Approval Form Test Submit empty form Validations" time="15.775" classname="Submit empty form Validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Approval Form Test Submit form after filling details" time="21.116" classname="Submit form after filling details">
+    </testcase>
+  </testsuite>
+  <testsuite name="Jira Update Form Test" timestamp="2023-11-15T18:30:09" tests="2" time="34.267" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Update Form Test Submit empty form Validations" time="15.440" classname="Submit empty form Validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Update Form Test Submit form after filling details" time="18.673" classname="Submit form after filling details">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/ti/report/parser/junit/gojunit/testdata/cypress.xml
+++ b/ti/report/parser/junit/gojunit/testdata/cypress.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="147.803" tests="8" failures="0">
+  <testsuite name="Root Suite" timestamp="2023-11-15T18:28:15" tests="0" file="integration/70-pipeline/RunPipelineJiraApprovalStage.spec.ts" time="0.000" failures="0">
+  </testsuite>
+  <testsuite name="RUN PIPELINE MODAL - Jira Approval Stage" timestamp="2023-11-15T18:28:15" tests="1" time="0.000" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage should display the delete pipeline stage modal" time="13.856" classname="should display the delete pipeline stage modal">
+    </testcase>
+  </testsuite>
+  <testsuite name="Jira Create Form Test" timestamp="2023-11-15T18:28:29" tests="3" time="62.737" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit empty form Validations" time="15.354" classname="Submit empty form Validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit form with empty required fields validations" time="22.701" classname="Submit form with empty required fields validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Create Form Test Submit form after filling details" time="24.647" classname="Submit form after filling details">
+    </testcase>
+  </testsuite>
+  <testsuite name="Jira Approval Form Test" timestamp="2023-11-15T18:29:32" tests="2" time="36.923" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Approval Form Test Submit empty form Validations" time="15.775" classname="Submit empty form Validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Approval Form Test Submit form after filling details" time="21.116" classname="Submit form after filling details">
+    </testcase>
+  </testsuite>
+  <testsuite name="Jira Update Form Test" timestamp="2023-11-15T18:30:09" tests="2" time="34.267" failures="0">
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Update Form Test Submit empty form Validations" time="15.440" classname="Submit empty form Validations">
+    </testcase>
+    <testcase name="RUN PIPELINE MODAL - Jira Approval Stage Jira Update Form Test Submit form after filling details" time="18.673" classname="Submit form after filling details">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/ti/report/parser/junit/junit.go
+++ b/ti/report/parser/junit/junit.go
@@ -21,7 +21,7 @@ const (
 )
 
 // ParseTests parses XMLs and writes relevant data to the channel
-func ParseTests(paths []string, log *logrus.Logger) []*ti.TestCase {
+func ParseTests(paths []string, log *logrus.Logger, envs map[string]string) []*ti.TestCase {
 	files := getFiles(paths, log)
 
 	log.Debugln(fmt.Sprintf("list of files to collect test reports from: %s", files))
@@ -32,7 +32,7 @@ func ParseTests(paths []string, log *logrus.Logger) []*ti.TestCase {
 	totalTests := 0
 	var tests []*ti.TestCase
 	for _, file := range files {
-		suites, err := gojunit.IngestFile(file)
+		suites, err := gojunit.IngestFile(file, envs)
 		if err != nil {
 			log.WithError(err).WithField("file", file).
 				Errorln(fmt.Sprintf("could not parse file %s", file))

--- a/ti/report/parser/junit/junit.go
+++ b/ti/report/parser/junit/junit.go
@@ -20,6 +20,15 @@ const (
 	strMaxSize = 8000 // Keep the last 8k characters in each field.
 )
 
+const defaultRootSuiteName = "Root Suite"
+
+func getRootSuiteName(envs map[string]string) string {
+	if val, ok := envs["HARNESS_JUNIT_ROOT_SUITE_NAME"]; ok {
+		return val
+	}
+	return defaultRootSuiteName
+}
+
 // ParseTests parses XMLs and writes relevant data to the channel
 func ParseTests(paths []string, log *logrus.Logger, envs map[string]string) []*ti.TestCase {
 	files := getFiles(paths, log)
@@ -32,7 +41,7 @@ func ParseTests(paths []string, log *logrus.Logger, envs map[string]string) []*t
 	totalTests := 0
 	var tests []*ti.TestCase
 	for _, file := range files {
-		suites, err := gojunit.IngestFile(file, envs)
+		suites, err := gojunit.IngestFile(file, getRootSuiteName(envs))
 		if err != nil {
 			log.WithError(err).WithField("file", file).
 				Errorln(fmt.Sprintf("could not parse file %s", file))

--- a/ti/report/parser/junit/junit.go
+++ b/ti/report/parser/junit/junit.go
@@ -21,9 +21,10 @@ const (
 )
 
 const defaultRootSuiteName = "Root Suite"
+const rootSuiteEnvVariableName = "HARNESS_JUNIT_ROOT_SUITE_NAME"
 
 func getRootSuiteName(envs map[string]string) string {
-	if val, ok := envs["HARNESS_JUNIT_ROOT_SUITE_NAME"]; ok {
+	if val, ok := envs[rootSuiteEnvVariableName]; ok {
 		return val
 	}
 	return defaultRootSuiteName

--- a/ti/report/parser/junit/junit_test.go
+++ b/ti/report/parser/junit/junit_test.go
@@ -329,7 +329,7 @@ func Test_GetRootSuiteName(t *testing.T) {
 	}{
 		{
 			name: "Root suite name provided in environment variable",
-			args: args{envs: map[string]string{"HARNESS_JUNIT_ROOT_SUITE_NAME": "CustomRootSuite"}},
+			args: args{envs: map[string]string{rootSuiteEnvVariableName: "CustomRootSuite"}},
 			want: "CustomRootSuite",
 		},
 		{

--- a/ti/report/parser/junit/junit_test.go
+++ b/ti/report/parser/junit/junit_test.go
@@ -215,7 +215,7 @@ func TestGetTests_All(t *testing.T) {
 	var paths []string
 	paths = append(paths, getBaseDir()+"**/*.xml") // Regex to get all reports
 	envs := make(map[string]string)
-	
+
 	tests := ParseTests(paths, logrus.New(), envs)
 	exp := []*ti.TestCase{expectedPassedTest(), expectedErrorTest(), expectedFailedTest(), expectedSkippedTest()}
 	exp = append(exp, expectedNestedTests()...)

--- a/ti/report/parser/junit/junit_test.go
+++ b/ti/report/parser/junit/junit_test.go
@@ -214,8 +214,9 @@ func TestGetTests_All(t *testing.T) {
 	defer removeBaseDir() //nolint:errcheck
 	var paths []string
 	paths = append(paths, getBaseDir()+"**/*.xml") // Regex to get all reports
-
-	tests := ParseTests(paths, logrus.New())
+	envs := make(map[string]string)
+	
+	tests := ParseTests(paths, logrus.New(), envs)
 	exp := []*ti.TestCase{expectedPassedTest(), expectedErrorTest(), expectedFailedTest(), expectedSkippedTest()}
 	exp = append(exp, expectedNestedTests()...)
 	assert.ElementsMatch(t, exp, tests)
@@ -239,8 +240,9 @@ func TestGetTests_All_MultiplePaths(t *testing.T) {
 	var paths []string
 	// Add multiple paths to get repeated filenames. Tests should still be unique (per filename)
 	paths = append(paths, basePath+"a/*/*.xml", basePath+"a/**/*.xml", basePath+"a/b/c/d/*.xml") // Regex to get both reports
+	envs := make(map[string]string)
 
-	tests := ParseTests(paths, logrus.New())
+	tests := ParseTests(paths, logrus.New(), envs)
 	exp := []*ti.TestCase{expectedPassedTest(), expectedErrorTest(), expectedFailedTest(), expectedSkippedTest()}
 	assert.ElementsMatch(t, exp, tests)
 }
@@ -262,8 +264,9 @@ func TestGetTests_FirstRegex(t *testing.T) {
 	basePath := getBaseDir()
 	var paths []string
 	paths = append(paths, basePath+"a/b/*.xml") // Regex to get both reports
+	envs := make(map[string]string)
 
-	tests := ParseTests(paths, logrus.New())
+	tests := ParseTests(paths, logrus.New(), envs)
 	exp := []*ti.TestCase{expectedPassedTest(), expectedFailedTest()}
 	assert.ElementsMatch(t, exp, tests)
 }
@@ -285,8 +288,9 @@ func TestGetTests_SecondRegex(t *testing.T) {
 	basePath := getBaseDir()
 	var paths []string
 	paths = append(paths, basePath+"a/b/**/*2.xml") // Regex to get both reports
+	envs := make(map[string]string)
 
-	tests := ParseTests(paths, logrus.New())
+	tests := ParseTests(paths, logrus.New(), envs)
 	exp := []*ti.TestCase{expectedSkippedTest(), expectedErrorTest()}
 	assert.ElementsMatch(t, exp, tests)
 }
@@ -308,8 +312,9 @@ func TestGetTests_NoMatchingRegex(t *testing.T) {
 	basePath := getBaseDir()
 	var paths []string
 	paths = append(paths, basePath+"a/b/**/*3.xml") // Regex to get both reports
+	envs := make(map[string]string)
 
-	tests := ParseTests(paths, logrus.New())
+	tests := ParseTests(paths, logrus.New(), envs)
 	exp := []*ti.TestCase{}
 	assert.ElementsMatch(t, exp, tests)
 }

--- a/ti/report/parser/junit/junit_test.go
+++ b/ti/report/parser/junit/junit_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
 	"testing"
 
 	ti "github.com/harness/ti-client/types"
@@ -317,4 +316,35 @@ func TestGetTests_NoMatchingRegex(t *testing.T) {
 	tests := ParseTests(paths, logrus.New(), envs)
 	exp := []*ti.TestCase{}
 	assert.ElementsMatch(t, exp, tests)
+}
+
+func Test_GetRootSuiteName(t *testing.T) {
+	type args struct {
+		envs map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Root suite name provided in environment variable",
+			args: args{envs: map[string]string{"HARNESS_JUNIT_ROOT_SUITE_NAME": "CustomRootSuite"}},
+			want: "CustomRootSuite",
+		},
+		{
+			name: "No root suite name in environment variable, use default",
+			args: args{envs: map[string]string{}},
+			want: defaultRootSuiteName,
+		},
+		// Add more test cases as needed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRootSuiteName(tt.args.envs); got != tt.want {
+				t.Errorf("getRootSuiteName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/ti/report/report.go
+++ b/ti/report/report.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func ParseAndUploadTests(ctx context.Context, report api.TestReport, workDir, stepID string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg) error {
+func ParseAndUploadTests(ctx context.Context, report api.TestReport, workDir, stepID string, log *logrus.Logger, start time.Time, tiConfig *tiCfg.Cfg, envs map[string]string) error {
 	if report.Kind != api.Junit {
 		return fmt.Errorf("unknown report type: %s", report.Kind)
 	}
@@ -36,7 +36,7 @@ func ParseAndUploadTests(ctx context.Context, report api.TestReport, workDir, st
 		}
 	}
 
-	tests := junit.ParseTests(report.Junit.Paths, log)
+	tests := junit.ParseTests(report.Junit.Paths, log, envs)
 	if len(tests) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Please check the xml file in the test example to see the kind of xml we are trying to get the filename for. 
If there is a test suite called Root Suite then the filename used in that must be propagated to other test suites. If any test suite and test case does not have a filename then the one from the Root Suite must be used.