### PR TITLE
[feat]: [CI-9776]: Fix case for ignoreInstr

### DIFF
--- a/ti/instrumentation/instrumentation.go
+++ b/ti/instrumentation/instrumentation.go
@@ -169,6 +169,9 @@ func GetCmd(ctx context.Context, config *api.RunTestConfig, stepID, workspace st
 	isManual := IsManualExecution(cfg)
 	ignoreInstr := isManual || !config.RunOnlySelectedTests
 	cfg.SetIgnoreInstr(ignoreInstr)
+	if (cfg.GetIgnoreInstr()) {
+		config.RunOnlySelectedTests = false
+	}
 
 	// Get TI runner
 	config.Language = strings.ToLower(config.Language)

--- a/ti/instrumentation/instrumentation.go
+++ b/ti/instrumentation/instrumentation.go
@@ -169,7 +169,7 @@ func GetCmd(ctx context.Context, config *api.RunTestConfig, stepID, workspace st
 	isManual := IsManualExecution(cfg)
 	ignoreInstr := isManual || !config.RunOnlySelectedTests
 	cfg.SetIgnoreInstr(ignoreInstr)
-	if (cfg.GetIgnoreInstr()) {
+	if cfg.GetIgnoreInstr() {
 		config.RunOnlySelectedTests = false
 	}
 


### PR DESCRIPTION
Before if it was a manual execution, RunOnlySelected tests was made false in the test selection part but now that was skipped. And hence in case of manual execution we were running selected tests which were empty since we did not select any tests to run. Found this issue when trying to setup harness code with TI since that is the only flow we are seeing TI defined manual executions still. 