### PR TITLE
[feat]: [CI-11342]: Fix picking gradlew

### DIFF
--- a/ti/instrumentation/java/gradle.go
+++ b/ti/instrumentation/java/gradle.go
@@ -82,8 +82,10 @@ The following needs to be added to a build.gradle to make it compatible with tes
 func (g *gradleRunner) GetCmd(ctx context.Context, tests []ti.RunnableTest, userArgs, workspace,
 	agentConfigPath, agentInstallDir string, ignoreInstr, runAll bool, runnerArgs common.RunnerArgs) (string, error) {
 	// Check if gradlew exists. If not, fallback to gradle
+	gradlewPath := filepath.Join(workspace, "gradlew")
+
 	gc := gradleWrapperCmd
-	_, err := g.fs.Stat("gradlew")
+	_, err := g.fs.Stat(gradlewPath)
 	if errors.Is(err, os.ErrNotExist) {
 		gc = gradleCmd
 	}


### PR DESCRIPTION
Currently we are checking for gradlew in / instead of /harness. This change will check for gradlew in the correct place