### PR TITLE
[CI-11492]: Add autodetection splitting

### DIFF
--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -197,26 +197,9 @@ func waitForFileWithTimeout(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
 		if !tiConfig.IsLockedRuby() {
 			return nil
 		}
-
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timeout waiting for agent download")
 		}
-
-		time.Sleep(time.Millisecond * 100)
-	}
-}
-
-func waitForFileWithTimeoutPy(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
-	deadline := time.Now().Add(timeout)
-	for {
-		if !tiConfig.IsLockedPython() {
-			return nil
-		}
-
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for agent download")
-		}
-
 		time.Sleep(time.Millisecond * 100)
 	}
 }

--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -194,12 +194,12 @@ func GetReplacer(
 func waitForFileWithTimeout(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
 	deadline := time.Now().Add(timeout)
 	for {
+		time.Sleep(time.Second * 1)
 		if !tiConfig.IsZipLocked() {
 			return nil
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timeout waiting for agent download")
 		}
-		time.Sleep(time.Millisecond * 100)
 	}
 }

--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -17,7 +17,6 @@ import (
 	v3 "github.com/harness/godotenv/v3"
 	"github.com/harness/lite-engine/api"
 	"github.com/harness/lite-engine/engine/spec"
-	"github.com/harness/lite-engine/internal/filesystem"
 	"github.com/harness/lite-engine/livelog"
 	"github.com/harness/lite-engine/logstream"
 	"github.com/harness/lite-engine/logstream/remote"
@@ -192,11 +191,25 @@ func GetReplacer(
 	return logstream.NewReplacer(wc, secrets)
 }
 
-func waitForFileWithTimeout(timeout time.Duration, filename string, fs filesystem.FileSystem) error {
+func waitForFileWithTimeout(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
 	deadline := time.Now().Add(timeout)
 	for {
-		_, err := fs.Stat(filename)
-		if err == nil {
+		if !tiConfig.IsLockedRuby() {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for agent download")
+		}
+
+		time.Sleep(time.Millisecond * 100)
+	}
+}
+
+func waitForFileWithTimeoutPy(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if !tiConfig.IsLockedPython() {
 			return nil
 		}
 

--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -191,7 +191,7 @@ func GetReplacer(
 	return logstream.NewReplacer(wc, secrets)
 }
 
-func waitForFileWithTimeout(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
+func waitForZipUnlock(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
 	deadline := time.Now().Add(timeout)
 	for {
 		time.Sleep(time.Second * 1)

--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -194,7 +194,7 @@ func GetReplacer(
 func waitForFileWithTimeout(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
 	deadline := time.Now().Add(timeout)
 	for {
-		if !tiConfig.IsLockedRuby() {
+		if !tiConfig.IsZipLocked() {
 			return nil
 		}
 		if time.Now().After(deadline) {

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -314,9 +314,10 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 	repoPathPython := filepath.Join(agentPaths["python"], "harness", "python-agent-v2")
 	stepIdx, _ := instrumentation.GetStepStrategyIteration(envs)
 	shouldWait := instrumentation.IsStepParallelismEnabled(envs) && stepIdx > 0
+	log.Infoln("Starting lock on step", stepIdx)
 	tiConfig.LockZip()
 	if shouldWait {
-		err = waitForFileWithTimeout(20*time.Second, tiConfig) // Wait for up to 10 seconds
+		err = waitForFileWithTimeout(30*time.Second, tiConfig) // Wait for up to 10 seconds
 		if err != nil {
 			log.WithError(err).Errorln("timed out while unzipping testInfo with retry")
 			return "", "", err
@@ -334,6 +335,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 		}
 		tiConfig.UnlockZip()
 	}
+	log.Infoln("unlocking on step", stepIdx)
 
 	if !isPsh {
 		preCmd = fmt.Sprintf("\nbundle add rspec_junit_formatter || true;\nbundle add harness_ruby_agent --path %q --version %q || true;", repoPath, "0.0.1")

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -275,7 +275,7 @@ func createJavaConfigFile(tmpDir string, fs filesystem.FileSystem, log *logrus.L
 
 // Here we are setting up env var to invoke agant along with creating config file and .bazelrc file
 //
-//nolint:funlen
+//nolint:funlen,gocyclo,lll
 func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *logrus.Logger, envs, agentPaths map[string]string, isPsh bool, tiConfig *tiCfg.Cfg) (preCmd, filterFilePath string, err error) {
 	splitIdx := 0
 	if instrumentation.IsParallelismEnabled(envs) {

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -285,6 +285,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 
 	outDir, err := createOutDir(tmpFilePath, fs, log)
 	if err != nil {
+		log.WithError(err).Errorln("failed to create outDir")
 		return "", "", err
 	}
 
@@ -313,6 +314,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 	// Ruby
 	repoPath, err := ruby.UnzipAndGetTestInfo(agentPaths["ruby"], log)
 	if err != nil {
+		log.WithError(err).Errorln("failed to unzip and get test info")
 		return "", "", err
 	}
 
@@ -417,6 +419,7 @@ func createSelectedTestFile(ctx context.Context, fs filesystem.FileSystem, stepI
 	err = filter.PopulateItemInFilterFile(resp, filterFilePath, fs, isFilterFilePresent)
 
 	if err != nil {
+		log.WithError(err).Errorln("failed to populate items in filterfile")
 		return err
 	}
 	return nil

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -203,17 +203,18 @@ func getTestsSelection(ctx context.Context, fs filesystem.FileSystem, stepID, wo
 	selection, err = instrumentation.SelectTests(ctx, workspace, filesWithpkg, runOnlySelectedTests, stepID, fs, tiConfig)
 	if err != nil {
 		log.WithError(err).Errorln("An unexpected error occurred during test selection. Running all tests.")
-		return selection, false
+		runOnlySelectedTests = false
 	} else if selection.SelectAll {
 		log.Infoln("Test Intelligence determined to run all the tests")
-		return selection, false
+		runOnlySelectedTests = false
 	} else {
 		log.Infoln(fmt.Sprintf("Running tests selected by Test Intelligence: %s", selection.Tests))
+		runOnlySelectedTests = true
 	}
 
 	// Test splitting: only when parallelism is enabled
 	if instrumentation.IsParallelismEnabled(envs) {
-		instrumentation.ComputeSelectedTestsV2(ctx, runV2Config, log, &selection, stepID, workspace, envs, tiConfig)
+		instrumentation.ComputeSelectedTestsV2(ctx, runV2Config, log, &selection, stepID, workspace, envs, tiConfig, runOnlySelectedTests, fs)
 	}
 
 	return selection, true

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -314,7 +314,6 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 	repoPathPython := filepath.Join(agentPaths["python"], "harness", "python-agent-v2")
 	stepIdx, _ := instrumentation.GetStepStrategyIteration(envs)
 	shouldWait := instrumentation.IsStepParallelismEnabled(envs) && stepIdx > 0
-	log.Infoln("Starting lock on step", stepIdx)
 	if shouldWait {
 		err = waitForFileWithTimeout(30*time.Second, tiConfig) // Wait for up to 10 seconds
 		if err != nil {
@@ -322,6 +321,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 			return "", "", err
 		}
 	} else {
+		log.Infoln("Starting lock on step", stepIdx)
 		tiConfig.LockZip()
 		repoPath, err = ruby.UnzipAndGetTestInfo(agentPaths["ruby"], log)
 		if err != nil {

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -312,7 +312,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 	agentArg := fmt.Sprintf(javaAgentV2Arg, javaAgentPath, iniFilePath)
 	envs["JAVA_TOOL_OPTIONS"] = agentArg
 	// Ruby
-	repoPath := ""
+	repoPath := filepath.Join(agentPaths["ruby"], "harness", "ruby-agent")
 	stepIdx, _ := instrumentation.GetStepStrategyIteration(envs)
 	shouldWait := instrumentation.IsStepParallelismEnabled(envs) && stepIdx > 0
 	var statusFilePath = filepath.Join(tmpFilePath, "unzip.done")

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -315,7 +315,6 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 	stepIdx, _ := instrumentation.GetStepStrategyIteration(envs)
 	shouldWait := instrumentation.IsStepParallelismEnabled(envs) && stepIdx > 0
 	log.Infoln("Starting lock on step", stepIdx)
-	tiConfig.LockZip()
 	if shouldWait {
 		err = waitForFileWithTimeout(30*time.Second, tiConfig) // Wait for up to 10 seconds
 		if err != nil {
@@ -323,6 +322,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 			return "", "", err
 		}
 	} else {
+		tiConfig.LockZip()
 		repoPath, err = ruby.UnzipAndGetTestInfo(agentPaths["ruby"], log)
 		if err != nil {
 			log.WithError(err).Errorln("failed to unzip and get test info")

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -314,7 +314,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 	repoPathPython := filepath.Join(agentPaths["python"], "harness", "python-agent-v2")
 	stepIdx, _ := instrumentation.GetStepStrategyIteration(envs)
 	shouldWait := instrumentation.IsStepParallelismEnabled(envs) && stepIdx > 0
-	tiConfig.LockZipForRuby()
+	tiConfig.LockZip()
 	if shouldWait {
 		err = waitForFileWithTimeout(20*time.Second, tiConfig) // Wait for up to 10 seconds
 		if err != nil {
@@ -332,7 +332,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 		if err != nil {
 			return "", "", err
 		}
-		tiConfig.UnlockZipForRuby()
+		tiConfig.UnlockZip()
 	}
 
 	if !isPsh {

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -317,7 +317,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 	stepIdx, _ := instrumentation.GetStepStrategyIteration(envs)
 	shouldWait := instrumentation.IsStepParallelismEnabled(envs) && stepIdx > 0
 	if shouldWait {
-		err = waitForFileWithTimeout(waitTimeoutInSec*time.Second, tiConfig) // Wait for up to 10 seconds
+		err = waitForZipUnlock(waitTimeoutInSec*time.Second, tiConfig) // Wait for up to 10 seconds
 		if err != nil {
 			log.WithError(err).Errorln("timed out while unzipping testInfo with retry")
 			return "", "", err

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -214,10 +214,10 @@ func getTestsSelection(ctx context.Context, fs filesystem.FileSystem, stepID, wo
 
 	// Test splitting: only when parallelism is enabled
 	if instrumentation.IsParallelismEnabled(envs) {
-		instrumentation.ComputeSelectedTestsV2(ctx, runV2Config, log, &selection, stepID, workspace, envs, tiConfig, runOnlySelectedTests, fs)
+		runOnlySelectedTests = instrumentation.ComputeSelectedTestsV2(ctx, runV2Config, log, &selection, stepID, workspace, envs, tiConfig, runOnlySelectedTests, fs)
 	}
 
-	return selection, true
+	return selection, runOnlySelectedTests
 }
 
 func createOutDir(tmpDir string, fs filesystem.FileSystem, log *logrus.Logger) (string, error) {

--- a/pipeline/runtime/runtestsV2_test.go
+++ b/pipeline/runtime/runtestsV2_test.go
@@ -138,6 +138,7 @@ func Test_getPreCmd(t *testing.T) {
 		workspace   string
 		tmpFilePath string
 		fs          filesystem.FileSystem
+		tiConfig    *tiCfg.Cfg
 		log         *logrus.Logger
 		envs        map[string]string
 		agentPaths  map[string]string
@@ -153,7 +154,7 @@ func Test_getPreCmd(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := getPreCmd(tt.args.workspace, tt.args.tmpFilePath, tt.args.fs, tt.args.log, tt.args.envs, tt.args.agentPaths, false)
+			got, got1, err := getPreCmd(tt.args.workspace, tt.args.tmpFilePath, tt.args.fs, tt.args.log, tt.args.envs, tt.args.agentPaths, false, tt.args.tiConfig)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPreCmd() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/ti/config/config.go
+++ b/ti/config/config.go
@@ -20,7 +20,6 @@ type stepFeature struct {
 type Cfg struct {
 	mu              *sync.Mutex
 	rubylocked      bool
-	pythonlocked    bool
 	client          *client.HTTPClient
 	sourceBranch    string
 	targetBranch    string
@@ -136,15 +135,7 @@ func (c *Cfg) LockZipForRuby() {
 func (c *Cfg) UnlockZipForRuby() {
 	c.rubylocked = false
 }
-func (c *Cfg) LockZipForPython() {
-	c.pythonlocked = true
-}
-func (c *Cfg) UnlockZipForPython() {
-	c.pythonlocked = false
-}
+
 func (c *Cfg) IsLockedRuby() bool {
 	return c.rubylocked
-}
-func (c *Cfg) IsLockedPython() bool {
-	return c.pythonlocked
 }

--- a/ti/config/config.go
+++ b/ti/config/config.go
@@ -20,7 +20,6 @@ type stepFeature struct {
 
 type Cfg struct {
 	mu              *sync.Mutex
-	zipmu           *sync.Mutex
 	ziplocked       int32 // 0 for unlocked, 1 for locked
 	client          *client.HTTPClient
 	sourceBranch    string
@@ -38,7 +37,6 @@ func New(endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stag
 		endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stageID, repo, sha, commitLink, skipVerify, "")
 	cfg := Cfg{
 		mu:              &sync.Mutex{},
-		zipmu:           &sync.Mutex{},
 		ziplocked:       0,
 		client:          tiClient,
 		sourceBranch:    sourceBranch,
@@ -134,12 +132,10 @@ func (c *Cfg) GetFeatureState(stepID string, feature types.SavingsFeature) (type
 }
 
 func (c *Cfg) LockZip() {
-	c.zipmu.Lock()
 	atomic.StoreInt32(&c.ziplocked, 1)
 }
 func (c *Cfg) UnlockZip() {
 	atomic.StoreInt32(&c.ziplocked, 0)
-	c.zipmu.Unlock()
 }
 
 func (c *Cfg) IsZipLocked() bool {

--- a/ti/config/config.go
+++ b/ti/config/config.go
@@ -38,6 +38,8 @@ func New(endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stag
 		endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stageID, repo, sha, commitLink, skipVerify, "")
 	cfg := Cfg{
 		mu:              &sync.Mutex{},
+		zipmu:           &sync.Mutex{},
+		ziplocked:       0,
 		client:          tiClient,
 		sourceBranch:    sourceBranch,
 		targetBranch:    targetBranch,

--- a/ti/config/config.go
+++ b/ti/config/config.go
@@ -37,7 +37,7 @@ func New(endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stag
 		endpoint, token, accountID, orgID, projectID, pipelineID, buildID, stageID, repo, sha, commitLink, skipVerify, "")
 	cfg := Cfg{
 		mu:              &sync.Mutex{},
-		ziplocked:       0,
+		ziplocked:       1,
 		client:          tiClient,
 		sourceBranch:    sourceBranch,
 		targetBranch:    targetBranch,

--- a/ti/config/config.go
+++ b/ti/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/harness/ti-client/client"
 	"github.com/harness/ti-client/types"
@@ -20,10 +19,8 @@ type stepFeature struct {
 
 type Cfg struct {
 	mu              *sync.Mutex
-	muruby          *sync.Mutex
-	mupy            *sync.Mutex
-	rubylocked      int32
-	pythonlocked    int32
+	rubylocked      bool
+	pythonlocked    bool
 	client          *client.HTTPClient
 	sourceBranch    string
 	targetBranch    string
@@ -134,20 +131,20 @@ func (c *Cfg) GetFeatureState(stepID string, feature types.SavingsFeature) (type
 }
 
 func (c *Cfg) LockZipForRuby() {
-	c.muruby.Lock()
+	c.rubylocked = true
 }
 func (c *Cfg) UnlockZipForRuby() {
-	c.muruby.Unlock()
+	c.rubylocked = false
 }
 func (c *Cfg) LockZipForPython() {
-	c.mupy.Lock()
+	c.pythonlocked = true
 }
 func (c *Cfg) UnlockZipForPython() {
-	c.mupy.Unlock()
+	c.pythonlocked = false
 }
 func (c *Cfg) IsLockedRuby() bool {
-	return atomic.LoadInt32(&c.rubylocked) == 1
+	return c.rubylocked
 }
 func (c *Cfg) IsLockedPython() bool {
-	return atomic.LoadInt32(&c.pythonlocked) == 1
+	return c.pythonlocked
 }

--- a/ti/instrumentation/instrumentation.go
+++ b/ti/instrumentation/instrumentation.go
@@ -150,7 +150,7 @@ func ComputeSelectedTestsV2(ctx context.Context, runConfigV2 *api.RunTestsV2Conf
 		// For full runs, detect all the tests in the repo and split them
 		// If autodetect fails or detects no tests, we run all tests in step 0
 		var err error
-		testGlobs := sanitizeTestGlob(runConfigV2.TestGlobs)
+		testGlobs := runConfigV2.TestGlobs
 		tests, err = AutoDetectTests(ctx, workspace, testGlobs, log, envs, fs)
 		if err != nil || len(tests) == 0 {
 			// AutoDetectTests output should be same across all the parallel steps. If one of the step

--- a/ti/instrumentation/instrumentation.go
+++ b/ti/instrumentation/instrumentation.go
@@ -146,7 +146,9 @@ func ComputeSelectedTestsV2(ctx context.Context, runConfigV2 *api.RunTestsV2Conf
 	tests := make([]ti.RunnableTest, 0)
 
 	//Autodetection
-	if runOnlySelectedTests {
+	if !runOnlySelectedTests {
+		// For full runs, detect all the tests in the repo and split them
+		// If autodetect fails or detects no tests, we run all tests in step 0
 		var err error
 		testGlobs := sanitizeTestGlob(runConfigV2.TestGlobs)
 		tests, err = AutoDetectTests(ctx, workspace, testGlobs, log, envs, fs)

--- a/ti/instrumentation/instrumentation.go
+++ b/ti/instrumentation/instrumentation.go
@@ -145,7 +145,7 @@ func ComputeSelectedTestsV2(ctx context.Context, runConfigV2 *api.RunTestsV2Conf
 	splitIdx, splitTotal := GetSplitIdxAndTotal(envs)
 	tests := make([]ti.RunnableTest, 0)
 
-	//Autodetection
+	// Autodetection
 	if !runOnlySelectedTests {
 		// For full runs, detect all the tests in the repo and split them
 		// If autodetect fails or detects no tests, we run all tests in step 0
@@ -169,12 +169,10 @@ func ComputeSelectedTestsV2(ctx context.Context, runConfigV2 *api.RunTestsV2Conf
 		}
 		// Auto-detected tests successfully
 		log.Infoln(fmt.Sprintf("Autodetected tests: %s", formatTests(tests)))
-
 	} else if len(selection.Tests) > 0 {
 		// In case of intelligent runs, split the tests from TI SelectTests API response
 		tests = selection.Tests
 	}
-
 	// Split the tests and send the split slice to the runner
 	splitTests, err := getSplitTests(ctx, log, tests, stepID, defaultTestSplitStrategy, splitIdx, splitTotal, tiConfig)
 	if err != nil {
@@ -340,7 +338,6 @@ func sanitizeTestGlob(globString string) []string {
 }
 
 func AutoDetectTests(ctx context.Context, workspace string, testGlobs []string, log *logrus.Logger, envs map[string]string, fs filesystem.FileSystem) ([]ti.RunnableTest, error) {
-
 	tests, err := java.AutoDetectTests(ctx, workspace, testGlobs)
 	if err != nil {
 		log.WithError(err).Errorln("Could not auto-detect java tests")

--- a/ti/instrumentation/instrumentation.go
+++ b/ti/instrumentation/instrumentation.go
@@ -135,12 +135,12 @@ func checkForBazelOptimization(ctx context.Context, workspace string, fs filesys
 // ComputeSelectedTestsV2 updates TI selection depending on the split strategy
 // AutoDetectTests output and parallelism configuration
 func ComputeSelectedTestsV2(ctx context.Context, runConfigV2 *api.RunTestsV2Config, log *logrus.Logger,
-	selection *ti.SelectTestsResp, stepID, workspace string, envs map[string]string, tiConfig *tiCfg.Cfg, runOnlySelectedTests bool, fs filesystem.FileSystem) {
+	selection *ti.SelectTestsResp, stepID, workspace string, envs map[string]string, tiConfig *tiCfg.Cfg, runOnlySelectedTests bool, fs filesystem.FileSystem) bool {
 	// Adding only this remove this condition later when we have complete specs
 	if runOnlySelectedTests && len(selection.Tests) == 0 {
 		// TI returned zero test cases to run. Skip parallelism as
 		// there are no tests to run
-		return
+		return runOnlySelectedTests
 	}
 	splitIdx, splitTotal := GetSplitIdxAndTotal(envs)
 	tests := make([]ti.RunnableTest, 0)
@@ -165,7 +165,7 @@ func ComputeSelectedTestsV2(ctx context.Context, runConfigV2 *api.RunTestsV2Conf
 				runOnlySelectedTests = true
 				log.WithError(err).Errorln("Error in auto-detecting tests for splitting, running all tests in parallel step 0")
 			}
-			return
+			return runOnlySelectedTests
 		}
 		// Auto-detected tests successfully
 		log.Infoln(fmt.Sprintf("Autodetected tests: %s", formatTests(tests)))
@@ -186,6 +186,7 @@ func ComputeSelectedTestsV2(ctx context.Context, runConfigV2 *api.RunTestsV2Conf
 
 	// Modify selections to run only selected tests
 	selection.Tests = splitTests
+	return runOnlySelectedTests
 }
 
 // computeSelectedTests updates TI selection and ignoreInstr in-place depending on the
@@ -342,22 +343,19 @@ func AutoDetectTests(ctx context.Context, workspace string, testGlobs []string, 
 
 	tests, err := java.AutoDetectTests(ctx, workspace, testGlobs)
 	if err != nil {
-		log.Errorln("Error in auto-detecting java tests")
-		return tests, err
+		log.WithError(err).Errorln("Could not auto-detect java tests")
 	}
 	rubyRunner := ruby.NewRubyRunner(log, fs, testGlobs, envs)
 	rubyTests, err := rubyRunner.AutoDetectTestsV2(ctx, workspace, testGlobs)
 	if err != nil {
-		log.Errorln("Error in auto-detecting ruby tests")
-		return tests, err
+		log.WithError(err).Errorln("Could not auto-detect ruby tests")
 	}
 	tests = append(tests, rubyTests...)
 
 	pyRunner := python.NewPytestRunner(log, fs, testGlobs)
 	pyTests, err := pyRunner.AutoDetectTests(ctx, workspace, testGlobs)
 	if err != nil {
-		log.Errorln("Error in auto-detecting python tests")
-		return tests, err
+		log.WithError(err).Errorln("Could not auto-detect python tests")
 	}
 	tests = append(tests, pyTests...)
 	return tests, nil

--- a/ti/instrumentation/instrumentation.go
+++ b/ti/instrumentation/instrumentation.go
@@ -346,7 +346,7 @@ func AutoDetectTests(ctx context.Context, workspace string, testGlobs []string, 
 		return tests, err
 	}
 	rubyRunner := ruby.NewRubyRunner(log, fs, testGlobs, envs)
-	rubyTests, err := rubyRunner.AutoDetectTests(ctx, workspace, testGlobs)
+	rubyTests, err := rubyRunner.AutoDetectTestsV2(ctx, workspace, testGlobs)
 	if err != nil {
 		log.Errorln("Error in auto-detecting ruby tests")
 		return tests, err

--- a/ti/instrumentation/java/helper.go
+++ b/ti/instrumentation/java/helper.go
@@ -6,6 +6,7 @@ package java
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -357,4 +358,16 @@ func parseBazelTestRule(r string) (ti.RunnableTest, error) {
 	test := ti.RunnableTest{Pkg: pkg, Class: cls}
 	test.Autodetect.Rule = r
 	return test, nil
+}
+
+func AutoDetectTests(ctx context.Context, workspace string, testGlobs []string) ([]ti.RunnableTest, error) {
+	tests := make([]ti.RunnableTest, 0)
+	javaTests := GetJavaTests(workspace, testGlobs)
+	scalaTests := GetScalaTests(workspace, testGlobs)
+	kotlinTests := GetKotlinTests(workspace, testGlobs)
+
+	tests = append(tests, javaTests...)
+	tests = append(tests, scalaTests...)
+	tests = append(tests, kotlinTests...)
+	return tests, nil
 }

--- a/ti/instrumentation/ruby/helper.go
+++ b/ti/instrumentation/ruby/helper.go
@@ -53,7 +53,7 @@ func getRubyTestsFromPattern(workspace string, testGlobs, excludeGlobs []string,
 	return tests
 }
 
-func getRubyTestsFromPatternV2(workspace string, testGlobs []string, excludeGlobs []string, log *logrus.Logger) []ti.RunnableTest {
+func getRubyTestsFromPatternV2(workspace string, testGlobs, excludeGlobs []string, log *logrus.Logger) []ti.RunnableTest {
 	tests := make([]ti.RunnableTest, 0)
 	// iterate over all the test globs
 	for _, testGlob := range testGlobs {
@@ -105,7 +105,7 @@ func GetRubyTests(workspace string, testGlobs, excludeGlobs []string, log *logru
 
 // GetRubyTests returns list of RunnableTests in the workspace with python extension.
 // In case of errors, return empty list
-func GetRubyTestsV2(workspace string, testGlobs []string, excludeGlobs []string, log *logrus.Logger) ([]ti.RunnableTest, error) {
+func GetRubyTestsV2(workspace string, testGlobs, excludeGlobs []string, log *logrus.Logger) ([]ti.RunnableTest, error) {
 	if len(testGlobs) == 0 {
 		testGlobs = defaultTestGlobs
 	}

--- a/ti/instrumentation/ruby/helper.go
+++ b/ti/instrumentation/ruby/helper.go
@@ -53,6 +53,30 @@ func getRubyTestsFromPattern(workspace string, testGlobs, excludeGlobs []string,
 	return tests
 }
 
+func getRubyTestsFromPatternV2(workspace string, testGlobs []string, excludeGlobs []string, log *logrus.Logger) []ti.RunnableTest {
+	tests := make([]ti.RunnableTest, 0)
+	// iterate over all the test globs
+	for _, testGlob := range testGlobs {
+		// find all the files matching the glob
+		testGlob = filepath.Join(workspace, testGlob)
+		matches, err := zglob.Glob(testGlob)
+		if err != nil {
+			log.Info(fmt.Sprintf("could not find ruby tests using %s: %s", testGlob, err))
+		}
+		// iterate over all the matches
+		for _, match := range matches {
+			// append a new RunnableTest to the tests slice if its a file
+			if info, err := os.Stat(match); err == nil && !info.IsDir() && !matchedAny(match, excludeGlobs) {
+				tests = append(tests, ti.RunnableTest{
+					Class: match,
+				})
+			}
+		}
+	}
+
+	return tests
+}
+
 func matchedAny(class string, globs []string) bool {
 	for _, glob := range globs {
 		if matchedExclude, _ := zglob.Match(glob, class); matchedExclude {
@@ -72,6 +96,23 @@ func GetRubyTests(workspace string, testGlobs, excludeGlobs []string, log *logru
 	log.Infoln(fmt.Sprintf("workspace: %v", workspace))
 
 	tests := getRubyTestsFromPattern(workspace, testGlobs, excludeGlobs, log)
+
+	if len(tests) == 0 {
+		return tests, fmt.Errorf("no ruby tests found with the given patterns %v", testGlobs)
+	}
+	return tests, nil
+}
+
+// GetRubyTests returns list of RunnableTests in the workspace with python extension.
+// In case of errors, return empty list
+func GetRubyTestsV2(workspace string, testGlobs []string, excludeGlobs []string, log *logrus.Logger) ([]ti.RunnableTest, error) {
+	if len(testGlobs) == 0 {
+		testGlobs = defaultTestGlobs
+	}
+	log.Infoln(fmt.Sprintf("testGlobs: %v", testGlobs))
+	log.Infoln(fmt.Sprintf("workspace: %v", workspace))
+
+	tests := getRubyTestsFromPatternV2(workspace, testGlobs, excludeGlobs, log)
 
 	if len(tests) == 0 {
 		return tests, fmt.Errorf("no ruby tests found with the given patterns %v", testGlobs)

--- a/ti/instrumentation/ruby/helper.go
+++ b/ti/instrumentation/ruby/helper.go
@@ -69,6 +69,8 @@ func GetRubyTests(workspace string, testGlobs, excludeGlobs []string, log *logru
 		testGlobs = defaultTestGlobs
 	}
 	log.Infoln(fmt.Sprintf("testGlobs: %v", testGlobs))
+	log.Infoln(fmt.Sprintf("workspace: %v", workspace))
+
 	tests := getRubyTestsFromPattern(workspace, testGlobs, excludeGlobs, log)
 
 	if len(tests) == 0 {

--- a/ti/instrumentation/ruby/rspec.go
+++ b/ti/instrumentation/ruby/rspec.go
@@ -47,6 +47,12 @@ func (m *rspecRunner) AutoDetectTests(ctx context.Context, workspace string, tes
 	return rubyTests, err
 }
 
+func (m *rspecRunner) AutoDetectTestsV2(ctx context.Context, workspace string, testGlobs []string) ([]ti.RunnableTest, error) {
+	testGlobs, excludeGlobs := GetRubyGlobs(testGlobs, m.envs)
+	rubyTests, err := GetRubyTestsV2(workspace, testGlobs, excludeGlobs, m.log)
+	return rubyTests, err
+}
+
 func (m *rspecRunner) ReadPackages(workspace string, files []ti.File) []ti.File {
 	return files
 }


### PR DESCRIPTION
Added auto-test-detection for java, ruby and python for test splitting and parallelism.
In case of prallelism if its first run or if all cases are selected then tests will be auto detected and populated in filter file.
![Uploading image.png…]()
