### PR TITLE
[feat]: [CI-12466]: Initialize optimizationState to empty string

### DIFF
--- a/pipeline/runtime/run.go
+++ b/pipeline/runtime/run.go
@@ -32,7 +32,7 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 	step.Entrypoint = r.Run.Entrypoint
 	setTiEnvVariables(step, tiConfig)
 
-	optimizationState := types.DISABLED
+	var optimizationState types.IntelligenceExecutionState
 	exportEnvFile := fmt.Sprintf("%s/%s-export.env", pipeline.SharedVolPath, step.ID)
 	step.Envs["DRONE_ENV"] = exportEnvFile
 

--- a/pipeline/runtime/runtest.go
+++ b/pipeline/runtime/runtest.go
@@ -43,7 +43,7 @@ func executeRunTestStep(ctx context.Context, f RunFunc, r *api.StartStepRequest,
 	}
 
 	start := time.Now()
-	optimizationState := types.DISABLED
+	var optimizationState types.IntelligenceExecutionState
 	cmd, err := instrumentation.GetCmd(ctx, &r.RunTest, r.Name, r.WorkingDir, log, r.Envs, tiConfig)
 	if err != nil {
 		return nil, nil, nil, nil, nil, string(optimizationState), err

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -46,7 +46,7 @@ func executeRunTestsV2Step(ctx context.Context, f RunFunc, r *api.StartStepReque
 	fs := filesystem.New()
 	log := logrus.New()
 	log.Out = out
-	optimizationState := types.DISABLED
+	var optimizationState types.IntelligenceExecutionState
 	step := toStep(r)
 	setTiEnvVariables(step, tiConfig)
 	agentPaths := make(map[string]string)


### PR DESCRIPTION
optimizationState should be initialized to an empty string and should only contain a non empty value if the FF to get optimization state is enabled. This will ensure backward compatibility of a vm runner with an older delegate