### PR TITLE
[feat]: [CI-12471]: Send testglobs from lite-engine to ti-service

### DIFF
--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -511,7 +511,11 @@ func sanitizeTestGlobsV2(globStrings []string) []string {
 	for _, globString := range globStrings {
 		if globString != "" {
 			splitted := strings.Split(globString, ",")
-			result = append(result, splitted...)
+			for _, s := range splitted {
+				if s != "" {
+					result = append(result, s)
+				}
+			}
 		}
 	}
 	return result

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/drone/runner-go/pipeline/runtime"
@@ -200,7 +201,8 @@ func getTestsSelection(ctx context.Context, fs filesystem.FileSystem, stepID, wo
 		}
 	}
 	filesWithpkg := java.ReadPkgs(log, fs, workspace, files)
-	selection, err = instrumentation.SelectTests(ctx, workspace, filesWithpkg, runOnlySelectedTests, stepID, fs, tiConfig)
+	testGlobs := sanitizeTestGlobsV2(runV2Config.TestGlobs)
+	selection, err = instrumentation.SelectTests(ctx, workspace, filesWithpkg, runOnlySelectedTests, stepID, testGlobs, fs, tiConfig)
 	if err != nil {
 		log.WithError(err).Errorln("An unexpected error occurred during test selection. Running all tests.")
 		runOnlySelectedTests = false
@@ -214,7 +216,7 @@ func getTestsSelection(ctx context.Context, fs filesystem.FileSystem, stepID, wo
 
 	// Test splitting: only when parallelism is enabled
 	if instrumentation.IsParallelismEnabled(envs) {
-		runOnlySelectedTests = instrumentation.ComputeSelectedTestsV2(ctx, runV2Config, log, &selection, stepID, workspace, envs, tiConfig, runOnlySelectedTests, fs)
+		runOnlySelectedTests = instrumentation.ComputeSelectedTestsV2(ctx, runV2Config, log, &selection, stepID, workspace, envs, testGlobs, tiConfig, runOnlySelectedTests, fs)
 	}
 
 	return selection, runOnlySelectedTests
@@ -502,4 +504,15 @@ func collectTestReportsAndCg(ctx context.Context, log *logrus.Logger, r *api.Sta
 		log.WithField("error", crErr).Errorln(fmt.Sprintf("Failed to upload report. Time taken: %s", time.Since(reportStart)))
 	}
 	return cgErr
+}
+
+func sanitizeTestGlobsV2(globStrings []string) []string {
+	var result []string
+	for _, globString := range globStrings {
+		if globString != "" {
+			splitted := strings.Split(globString, ",")
+			result = append(result, splitted...)
+		}
+	}
+	return result
 }

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -507,7 +507,7 @@ func collectTestReportsAndCg(ctx context.Context, log *logrus.Logger, r *api.Sta
 }
 
 func sanitizeTestGlobsV2(globStrings []string) []string {
-	var result []string
+	var result = make([]string, 0)
 	for _, globString := range globStrings {
 		if globString != "" {
 			splitted := strings.Split(globString, ",")

--- a/pipeline/runtime/runtestsV2_test.go
+++ b/pipeline/runtime/runtestsV2_test.go
@@ -247,3 +247,46 @@ func Test_writetoBazelrcFile(t *testing.T) {
 		}
 	})
 }
+
+func TestSanitizeTestGlobsV2(t *testing.T) {
+	tests := []struct {
+		name        string
+		globStrings []string
+		expected    []string
+	}{
+		{
+			name:        "Empty Input",
+			globStrings: []string{},
+			expected:    []string{},
+		},
+		{
+			name:        "Single Glob",
+			globStrings: []string{"*.txt"},
+			expected:    []string{"*.txt"},
+		},
+		{
+			name:        "Multiple Globs",
+			globStrings: []string{"*.txt,*.md,*.pdf"},
+			expected:    []string{"*.txt", "*.md", "*.pdf"},
+		},
+		{
+			name:        "Empty String in Input",
+			globStrings: []string{"", "*.txt,*.md,*.pdf"},
+			expected:    []string{"*.txt", "*.md", "*.pdf"},
+		},
+		{
+			name:        "Empty Globs in Input",
+			globStrings: []string{"", ""},
+			expected:    []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := sanitizeTestGlobsV2(test.globStrings)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("Test case %s failed. Expected: %v, Got: %v", test.name, test.expected, result)
+			}
+		})
+	}
+}

--- a/ti/instrumentation/utils.go
+++ b/ti/instrumentation/utils.go
@@ -420,7 +420,7 @@ func getAllJavaFilesInsideDirectory(directory string, changedFiles []ti.File, fi
 
 // selectTests takes a list of files which were changed as input and gets the tests
 // to be run corresponding to that.
-func SelectTests(ctx context.Context, workspace string, files []ti.File, runSelected bool, stepID string,
+func SelectTests(ctx context.Context, workspace string, files []ti.File, runSelected bool, stepID string, testGlobs []string,
 	fs filesystem.FileSystem, cfg *tiCfg.Cfg) (ti.SelectTestsResp, error) {
 	Log := logrus.New() // Revert
 	Log.Infoln("Info: starting test selection")
@@ -428,7 +428,7 @@ func SelectTests(ctx context.Context, workspace string, files []ti.File, runSele
 	if err != nil {
 		return ti.SelectTestsResp{}, err
 	}
-	req := &ti.SelectTestsReq{SelectAll: !runSelected, Files: files, TiConfig: tiConfigYaml}
+	req := &ti.SelectTestsReq{SelectAll: !runSelected, Files: files, TiConfig: tiConfigYaml, TestGlobs: testGlobs}
 	c := cfg.GetClient()
 	return c.SelectTests(ctx, stepID, cfg.GetSourceBranch(), cfg.GetTargetBranch(), req)
 }


### PR DESCRIPTION
Currently test globs passed from the user in the runtest and test steps are not being sent to ti-service. TI service needs them to check if a changed file is a test file or no

Testing for vagrant ruby repo which does not use default globs

Before changes, if a test file is modified, it is not selected to run
<img width="1192" alt="Screenshot 2024-05-09 at 3 05 48 PM" src="https://github.com/harness/lite-engine/assets/114451080/dbdc5755-787a-4e5e-a59f-f02a2e26ed36">



With changes, modfying a test file we can see tests are selected (prints look different for debugging)
<img width="1192" alt="Screenshot 2024-05-09 at 2 58 26 PM" src="https://github.com/harness/lite-engine/assets/114451080/a2be3ef1-7056-4ebb-b5ae-c22b88a4a604">
