### PR TITLE
[feat]: [CI-12621]: Upload savings for DLC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/harness/ti-client v0.0.0-20240412182020-48619e4621e9
+	github.com/harness/ti-client v0.0.0-20240524184141-c83b454996d0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/linkedin/goavro/v2 v2.12.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/harness/godotenv/v2 v2.0.0 h1:9Hpa8PfXQ5PJ8kGmSLp4eEdPLhVXsUMGMHrH7yo
 github.com/harness/godotenv/v2 v2.0.0/go.mod h1:f2Xdq/sKp6M464DNmLny9JhQIrPPp2yRlha9q78ZhAs=
 github.com/harness/godotenv/v3 v3.0.0 h1:1YJU9nUk4tQygHOYkm+NZ5jL9IZQ3UqyBspCqL3EMQQ=
 github.com/harness/godotenv/v3 v3.0.0/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/ti-client v0.0.0-20240412182020-48619e4621e9 h1:WUXfdwuOPywDh2+YjepfMtgKXCo48PWXrO3bqAZ4Lhw=
-github.com/harness/ti-client v0.0.0-20240412182020-48619e4621e9/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
+github.com/harness/ti-client v0.0.0-20240524184141-c83b454996d0 h1:ZqtBCFmHx1t5XtQUu2d7L3+9G/6Ya9x77jIoP6mbnXM=
+github.com/harness/ti-client v0.0.0-20240524184141-c83b454996d0/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/pipeline/runtime/run.go
+++ b/pipeline/runtime/run.go
@@ -73,6 +73,7 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 	} else {
 		outputSecretsFile = fmt.Sprintf("%s/%s-output-secrets.env", pipeline.SharedVolPath, step.ID)
 	}
+
 	// Plugins can use HARNESS_OUTPUT_SECRET_FILE to write the output secrets to a file.
 	step.Envs["HARNESS_OUTPUT_SECRET_FILE"] = outputSecretsFile
 
@@ -81,6 +82,10 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 
 	if metadataFile, found := step.Envs["PLUGIN_METADATA_FILE"]; found {
 		step.Envs["PLUGIN_METADATA_FILE"] = fmt.Sprintf("%s/%s-%s", pipeline.SharedVolPath, step.ID, metadataFile)
+	}
+
+	if cacheMetricsFile, found := step.Envs["PLUGIN_CACHE_METRICS_FILE"]; found {
+		step.Envs["PLUGIN_CACHE_METRICS_FILE"] = fmt.Sprintf("%s/%s-%s", pipeline.SharedVolPath, step.ID, cacheMetricsFile)
 	}
 
 	log := logrus.New()
@@ -97,7 +102,7 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 
 	// Parse and upload savings to TI
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/pipeline/runtime/run.go
+++ b/pipeline/runtime/run.go
@@ -143,7 +143,7 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 			}
 		}
 
-		//checking exported secrets from plugins if any
+		// checking exported secrets from plugins if any
 		if _, err := os.Stat(outputSecretsFile); err == nil {
 			secrets, err := fetchExportedVarsFromEnvFile(outputSecretsFile, out, useCINewGodotEnvVersion)
 			if err != nil {
@@ -157,7 +157,6 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 				}
 				outputsV2 = append(outputsV2, output)
 			}
-
 		}
 
 		return exited, outputs, exportEnvs, artifact, outputsV2, string(optimizationState), finalErr

--- a/pipeline/runtime/run.go
+++ b/pipeline/runtime/run.go
@@ -25,7 +25,7 @@ const (
 	trueValue = "true"
 )
 
-func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out io.Writer, tiConfig *tiCfg.Cfg) ( //nolint:gocritic,gocyclo
+func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out io.Writer, tiConfig *tiCfg.Cfg) ( //nolint:gocritic,gocyclo,funlen
 	*runtime.State, map[string]string, map[string]string, []byte, []*api.OutputV2, string, error) {
 	start := time.Now()
 	step := toStep(r)

--- a/pipeline/runtime/runtest.go
+++ b/pipeline/runtime/runtest.go
@@ -82,7 +82,7 @@ func executeRunTestStep(ctx context.Context, f RunFunc, r *api.StartStepRequest,
 
 	// Parse and upload savings to TI
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -127,7 +127,7 @@ func executeRunTestsV2Step(ctx context.Context, f RunFunc, r *api.StartStepReque
 	}
 
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/ti/savings/dlc/dlc.go
+++ b/ti/savings/dlc/dlc.go
@@ -33,21 +33,18 @@ func GetFeatureState(cacheMetricsFile string, log *logrus.Logger) (types.Intelli
 
 	// Check if the file exists.
 	if _, err := os.Stat(cacheMetricsFile); os.IsNotExist(err) {
-		log.WithField("file", cacheMetricsFile).Error("Cache metrics file does not exist")
 		return state, err
 	}
 
 	// Read the JSON file containing the cache metrics.
 	data, err := os.ReadFile(cacheMetricsFile)
 	if err != nil {
-		log.WithField("file", cacheMetricsFile).Error("Failed to read cache metrics file")
 		return state, err
 	}
 
 	// Deserialize the JSON data into the CacheMetrics struct.
 	var metrics CacheMetrics
 	if err := json.Unmarshal(data, &metrics); err != nil {
-		log.WithField("file", cacheMetricsFile).Error("Failed to unmarshal cache metrics data")
 		return state, err
 	}
 

--- a/ti/savings/dlc/dlc.go
+++ b/ti/savings/dlc/dlc.go
@@ -1,0 +1,64 @@
+package dlc
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/harness/ti-client/types"
+	"github.com/sirupsen/logrus"
+)
+
+type (
+	// CacheMetrics represents the structure of the metrics data.
+	CacheMetrics struct {
+		TotalLayers int                 `json:"total_layers"`
+		Done        int                 `json:"done"`
+		Cached      int                 `json:"cached"`
+		Errored     int                 `json:"errored"`
+		Cancelled   int                 `json:"cancelled"`
+		Layers      map[int]LayerStatus `json:"layers"`
+	}
+
+	// LayerStatus details the status of each layer.
+	LayerStatus struct {
+		Status string
+		Time   float64 // Time in seconds; only set for DONE layers
+	}
+)
+
+// GetFeatureState evaluates the execution state of a feature based on cache metrics.
+func GetFeatureState(cacheMetricsFile string, log *logrus.Logger) (types.IntelligenceExecutionState, error) {
+	// Initialize the state as DISABLED by default.
+	state := types.DISABLED
+
+	// Check if the file exists.
+	if _, err := os.Stat(cacheMetricsFile); os.IsNotExist(err) {
+		log.WithField("file", cacheMetricsFile).Error("Cache metrics file does not exist")
+		return state, err
+	}
+
+	// Read the JSON file containing the cache metrics.
+	data, err := os.ReadFile(cacheMetricsFile)
+	if err != nil {
+		log.WithField("file", cacheMetricsFile).Error("Failed to read cache metrics file")
+		return state, err
+	}
+
+	// Deserialize the JSON data into the CacheMetrics struct.
+	var metrics CacheMetrics
+	if err := json.Unmarshal(data, &metrics); err != nil {
+		log.WithField("file", cacheMetricsFile).Error("Failed to unmarshal cache metrics data")
+		return state, err
+	}
+
+	// Determine the feature state based on the metrics.
+	if metrics.TotalLayers > 0 {
+		if metrics.Cached > 0 {
+			state = types.OPTIMIZED // It's an optimized run if there are cached layers.
+		} else {
+			state = types.FULL_RUN // It's a full run if total layers are non-zero and no cached layers.
+		}
+	}
+
+	return state, nil
+}

--- a/ti/savings/dlc/dlc.go
+++ b/ti/savings/dlc/dlc.go
@@ -15,7 +15,7 @@ type (
 		Done        int                 `json:"done"`
 		Cached      int                 `json:"cached"`
 		Errored     int                 `json:"errored"`
-		Cancelled   int                 `json:"cancelled"`
+		Canceled    int                 `json:"canceled"`
 		Layers      map[int]LayerStatus `json:"layers"`
 	}
 

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -49,11 +49,6 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 	// DLC Savings
 	if cacheMetricsFile, found := envs["PLUGIN_CACHE_METRICS_FILE"]; found {
 		if opts, ok := envs["PLUGIN_BUILDER_DRIVER_OPTS"]; ok && strings.Contains(opts, "harness/buildkit") {
-			// Both conditions are met
-			// Your code here
-			println("Both PLUGIN_CACHE_METRICS_FILE and PLUGIN_BUILDER_DRIVER_OPTS with specific value are found")
-			println("PLUGIN_CACHE_METRICS_FILE:", cacheMetricsFile)
-			println("PLUGIN_BUILDER_DRIVER_OPTS:", opts)
 			dlcState, err := dlc.GetFeatureState(cacheMetricsFile, log)
 			if err == nil {
 				states = append(states, dlcState)

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -60,7 +60,6 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 						types.DLC, time.Since(tiStart).Seconds())
 				}
 			}
-
 		}
 	}
 	// Cache Intel savings (Placeholder)

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -3,16 +3,18 @@ package savings
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	tiCfg "github.com/harness/lite-engine/ti/config"
 	"github.com/harness/lite-engine/ti/savings/cache"
+	"github.com/harness/lite-engine/ti/savings/dlc"
 	"github.com/harness/ti-client/types"
 	"github.com/sirupsen/logrus"
 )
 
 func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Logger, stepID string, cmdTimeTaken int64,
-	tiConfig *tiCfg.Cfg) types.IntelligenceExecutionState {
+	tiConfig *tiCfg.Cfg, envs map[string]string) types.IntelligenceExecutionState {
 	states := make([]types.IntelligenceExecutionState, 0)
 	// Cache Savings
 	start := time.Now()
@@ -44,7 +46,28 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 		}
 	}
 
-	// DLC Savings (Placeholder)
+	// DLC Savings
+	if cacheMetricsFile, found := envs["PLUGIN_CACHE_METRICS_FILE"]; found {
+		if opts, ok := envs["PLUGIN_BUILDER_DRIVER_OPTS"]; ok && strings.Contains(opts, "harness/buildkit") {
+			// Both conditions are met
+			// Your code here
+			println("Both PLUGIN_CACHE_METRICS_FILE and PLUGIN_BUILDER_DRIVER_OPTS with specific value are found")
+			println("PLUGIN_CACHE_METRICS_FILE:", cacheMetricsFile)
+			println("PLUGIN_BUILDER_DRIVER_OPTS:", opts)
+			dlcState, err := dlc.GetFeatureState(cacheMetricsFile, log)
+			if err == nil {
+				states = append(states, dlcState)
+				log.Infof("Computed docker layer caching execution details with state %s and time %dms", dlcState, cmdTimeTaken)
+				tiStart := time.Now()
+				tiErr := tiConfig.GetClient().WriteSavings(ctx, stepID, types.DLC, dlcState, cmdTimeTaken, types.SavingsRequest{})
+				if tiErr == nil {
+					log.Infof("Successfully uploaded savings for feature %s in %0.2f seconds",
+						types.DLC, time.Since(tiStart).Seconds())
+				}
+			}
+
+		}
+	}
 	// Cache Intel savings (Placeholder)
 	return getStepState(states)
 }


### PR DESCRIPTION
We will parse the cache metrics file created by the buildx plugin if it exists and upload savings data to ti-service