### PR TITLE
[feat]: [CI-12621]: Move cache metrics struct to ti-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/harness/ti-client v0.0.0-20240530221551-2c3416e89776
+	github.com/harness/ti-client v0.0.0-20240531180906-f9fdc47d7ffe
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/linkedin/goavro/v2 v2.12.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/harness/ti-client v0.0.0-20240531180906-f9fdc47d7ffe
+	github.com/harness/ti-client v0.0.0-20240531184205-9340ef702bc9
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/linkedin/goavro/v2 v2.12.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/harness/ti-client v0.0.0-20240531184205-9340ef702bc9
+	github.com/harness/ti-client v0.0.0-20240531185839-4d7ec0902d8a
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/linkedin/goavro/v2 v2.12.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/harness/godotenv/v3 v3.0.0 h1:1YJU9nUk4tQygHOYkm+NZ5jL9IZQ3UqyBspCqL3
 github.com/harness/godotenv/v3 v3.0.0/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
 github.com/harness/ti-client v0.0.0-20240530221551-2c3416e89776 h1:cOW3o4d+OcdH2vkOastbHrOAaM+YBX4BM0ULj66gpSI=
 github.com/harness/ti-client v0.0.0-20240530221551-2c3416e89776/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
+github.com/harness/ti-client v0.0.0-20240531180906-f9fdc47d7ffe h1:01oxAP8MrqKAve50FQInsn+Vrv1VDECoAGLOp6PUrtU=
+github.com/harness/ti-client v0.0.0-20240531180906-f9fdc47d7ffe/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,8 @@ github.com/harness/godotenv/v2 v2.0.0 h1:9Hpa8PfXQ5PJ8kGmSLp4eEdPLhVXsUMGMHrH7yo
 github.com/harness/godotenv/v2 v2.0.0/go.mod h1:f2Xdq/sKp6M464DNmLny9JhQIrPPp2yRlha9q78ZhAs=
 github.com/harness/godotenv/v3 v3.0.0 h1:1YJU9nUk4tQygHOYkm+NZ5jL9IZQ3UqyBspCqL3EMQQ=
 github.com/harness/godotenv/v3 v3.0.0/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/ti-client v0.0.0-20240530221551-2c3416e89776 h1:cOW3o4d+OcdH2vkOastbHrOAaM+YBX4BM0ULj66gpSI=
-github.com/harness/ti-client v0.0.0-20240530221551-2c3416e89776/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
-github.com/harness/ti-client v0.0.0-20240531180906-f9fdc47d7ffe h1:01oxAP8MrqKAve50FQInsn+Vrv1VDECoAGLOp6PUrtU=
-github.com/harness/ti-client v0.0.0-20240531180906-f9fdc47d7ffe/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
+github.com/harness/ti-client v0.0.0-20240531184205-9340ef702bc9 h1:XdXtuaKTN3U8QwCv0rVNYUI+MRv/edto2PuM96e+ZbE=
+github.com/harness/ti-client v0.0.0-20240531184205-9340ef702bc9/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/harness/godotenv/v2 v2.0.0 h1:9Hpa8PfXQ5PJ8kGmSLp4eEdPLhVXsUMGMHrH7yo
 github.com/harness/godotenv/v2 v2.0.0/go.mod h1:f2Xdq/sKp6M464DNmLny9JhQIrPPp2yRlha9q78ZhAs=
 github.com/harness/godotenv/v3 v3.0.0 h1:1YJU9nUk4tQygHOYkm+NZ5jL9IZQ3UqyBspCqL3EMQQ=
 github.com/harness/godotenv/v3 v3.0.0/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/ti-client v0.0.0-20240531184205-9340ef702bc9 h1:XdXtuaKTN3U8QwCv0rVNYUI+MRv/edto2PuM96e+ZbE=
-github.com/harness/ti-client v0.0.0-20240531184205-9340ef702bc9/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
+github.com/harness/ti-client v0.0.0-20240531185839-4d7ec0902d8a h1:1ETlOcamgFdI/DX0BNfLVVinwFpNG+bIWSXRkbK7j4s=
+github.com/harness/ti-client v0.0.0-20240531185839-4d7ec0902d8a/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/ti/savings/dlc/dlc.go
+++ b/ti/savings/dlc/dlc.go
@@ -5,25 +5,8 @@ import (
 	"os"
 
 	"github.com/harness/ti-client/types"
+	dlcTypes "github.com/harness/ti-client/types/cache/dlc"
 	"github.com/sirupsen/logrus"
-)
-
-type (
-	// CacheMetrics represents the structure of the metrics data.
-	CacheMetrics struct {
-		TotalLayers int                 `json:"total_layers"`
-		Done        int                 `json:"done"`
-		Cached      int                 `json:"cached"`
-		Errored     int                 `json:"errored"`
-		Canceled    int                 `json:"canceled"`
-		Layers      map[int]LayerStatus `json:"layers"`
-	}
-
-	// LayerStatus details the status of each layer.
-	LayerStatus struct {
-		Status string
-		Time   float64 // Time in seconds; only set for DONE layers
-	}
 )
 
 // GetFeatureState evaluates the execution state of a feature based on cache metrics.
@@ -43,7 +26,7 @@ func GetFeatureState(cacheMetricsFile string, log *logrus.Logger) (types.Intelli
 	}
 
 	// Deserialize the JSON data into the CacheMetrics struct.
-	var metrics CacheMetrics
+	var metrics dlcTypes.Metrics
 	if err := json.Unmarshal(data, &metrics); err != nil {
 		return state, err
 	}


### PR DESCRIPTION
Successful metrics parsing in lite-engine and upload to ti-service

<img width="1662" alt="Screenshot 2024-05-31 at 11 32 11 AM" src="https://github.com/harness/lite-engine/assets/114451080/7e3e812f-58c6-4a34-80cb-be39a6aef96a">


<img width="1663" alt="Screenshot 2024-05-31 at 11 33 19 AM" src="https://github.com/harness/lite-engine/assets/114451080/da6df0b1-3d59-43a5-a8cf-3bb119a2db24">


Example with ERROR layer
<img width="1728" alt="Screenshot 2024-05-31 at 11 54 01 AM" src="https://github.com/harness/lite-engine/assets/114451080/df030fde-3833-4b2c-a29c-9d5c03e63fc4">

