### PR TITLE
[feat]: [CI-12982]: Add ParseSavings Support for RunTestV2

### DIFF
--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -425,6 +425,15 @@ func createSelectedTestFile(ctx context.Context, fs filesystem.FileSystem, stepI
 	tiConfig *tiCfg.Cfg, tmpFilepath string, envs map[string]string, runV2Config *api.RunTestsV2Config, filterFilePath string) error {
 	isManualExecution := instrumentation.IsManualExecution(tiConfig)
 	resp, isFilterFilePresent := getTestsSelection(ctx, fs, stepID, workspace, log, isManualExecution, tiConfig, envs, runV2Config)
+	if tiConfig.GetParseSavings() {
+		if isFilterFilePresent {
+			// TI selected subset of tests
+			tiConfig.WriteFeatureState(stepID, types.TI, types.OPTIMIZED)
+		} else {
+			// TI selected all tests or returned an error which resulted in full run
+			tiConfig.WriteFeatureState(stepID, types.TI, types.FULL_RUN)
+		}
+	}
 
 	filterFileDir := fmt.Sprintf(filterV2Dir, tmpFilepath)
 


### PR DESCRIPTION
Full Run
<img width="1728" alt="Screenshot 2024-06-17 at 1 47 09 PM" src="https://github.com/harness/lite-engine/assets/114451080/1540a805-fef3-4abf-bd6c-ce131bb1bb82">

Optimized Run
<img width="1728" alt="Screenshot 2024-06-17 at 1 47 18 PM" src="https://github.com/harness/lite-engine/assets/114451080/10c08b8b-dac9-4b56-8799-b85dbedfbec6">

Savings Table
<img width="1663" alt="Screenshot 2024-06-17 at 1 47 48 PM" src="https://github.com/harness/lite-engine/assets/114451080/d817aad1-3a40-4241-aef0-867760d166b8">
