### PR TITLE
feat: [CI-12843]: Enable process information in LE logs

### DIFF
--- a/handler/setup.go
+++ b/handler/setup.go
@@ -22,7 +22,8 @@ import (
 )
 
 var (
-	statsInterval = 30 * time.Second
+	statsInterval          = 30 * time.Second
+	harnessEnableDebugLogs = "HARNESS_ENABLE_DEBUG_LOGS"
 )
 
 // HandleExecuteStep returns an http.HandlerFunc that executes a step
@@ -36,8 +37,11 @@ func HandleSetup(engine *engine.Engine) http.HandlerFunc {
 			WriteBadRequest(w, err)
 			return
 		}
-
-		collector := osstats.New(context.Background(), statsInterval)
+		logProcess := false
+		if val, ok := s.Envs[harnessEnableDebugLogs]; ok && val == "true" {
+			logProcess = true
+		}
+		collector := osstats.New(context.Background(), statsInterval, logProcess)
 
 		setProxyEnvs(s.Envs)
 		state := pipeline.GetState()

--- a/livelog/livelog.go
+++ b/livelog/livelog.go
@@ -220,13 +220,16 @@ func (b *Writer) flush() error {
 	lines := b.copy()
 	b.clear()
 	if len(lines) == 0 {
+		// print stats if no logs for 10 min
 		thresholdTime := time.Now().Add(-flushThresholdTime)
 		if b.lastFlushTime.Before(thresholdTime) {
 			osstats.DumpProcessInfo()
+			// reset lastFlushTime if stats were dumped
+			b.lastFlushTime = time.Now()
 		}
-		b.lastFlushTime = time.Now()
 		return nil
 	}
+	// reset lastFlushTime if logs are found
 	b.lastFlushTime = time.Now()
 	err := b.client.Write(context.Background(), b.key, lines)
 	if err != nil {

--- a/osstats/collector.go
+++ b/osstats/collector.go
@@ -130,7 +130,7 @@ func formatMB(val uint64) float64 {
 
 func (s *StatsCollector) get() (*osStat, error) {
 	if s.logProcess {
-		if err := s.dumpProcessInfo(); err != nil {
+		if err := DumpProcessInfo(); err != nil {
 			s.log.Errorln("Unable to log process info", err)
 		}
 	}
@@ -165,7 +165,7 @@ func (s *StatsCollector) get() (*osStat, error) {
 		MemAvailableMB: formatMB(vm.Available), MemUsedMB: formatMB(vm.Used), SwapMemPct: swap.UsedPercent, CPUTotal: s.cpuTotal}, nil
 }
 
-func (s *StatsCollector) dumpProcessInfo() error {
+func DumpProcessInfo() error {
 	// Retrieve list of processes
 	processes, err := process.Processes()
 	if err != nil {
@@ -206,7 +206,7 @@ func (s *StatsCollector) dumpProcessInfo() error {
 	if err != nil {
 		return err
 	}
-	s.log.Infoln("Process info: ", string(output))
+	logrus.Infoln("Process info: ", string(output))
 	return nil
 }
 

--- a/osstats/collector.go
+++ b/osstats/collector.go
@@ -131,7 +131,7 @@ func formatMB(val uint64) float64 {
 func (s *StatsCollector) get() (*osStat, error) {
 	if s.logProcess {
 		if err := s.dumpProcessInfo(); err != nil {
-			return nil, err
+			s.log.Errorln("Unable to log process info", err)
 		}
 	}
 


### PR DESCRIPTION
Added following changes.

1. Added process dump in collector if `HARNESS_ENABLE_DEBUG_LOGS` env is set
2. Added timeouts for log upload requests so that backoff can work.