### PR TITLE
[feat]: [CI-13358]: Show stage savings for cache intel

### DIFF
--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -208,8 +208,8 @@ func waitForZipUnlock(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
 	}
 }
 
-// CheckStepSuccess checks if the step was successful based on the return values
-func CheckStepSuccess(state *runtime.State, err error) bool {
+// checkStepSuccess checks if the step was successful based on the return values
+func checkStepSuccess(state *runtime.State, err error) bool {
 	if err == nil && state != nil && state.ExitCode == 0 && state.Exited {
 		return true
 	}

--- a/pipeline/runtime/common.go
+++ b/pipeline/runtime/common.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/drone/runner-go/pipeline/runtime"
 	v2 "github.com/harness/godotenv/v2"
 	v3 "github.com/harness/godotenv/v3"
 	"github.com/harness/lite-engine/api"
@@ -205,4 +206,12 @@ func waitForZipUnlock(timeout time.Duration, tiConfig *tiCfg.Cfg) error {
 			return fmt.Errorf("timeout waiting for agent download")
 		}
 	}
+}
+
+// CheckStepSuccess checks if the step was successful based on the return values
+func CheckStepSuccess(state *runtime.State, err error) bool {
+	if err == nil && state != nil && state.ExitCode == 0 && state.Exited {
+		return true
+	}
+	return false
 }

--- a/pipeline/runtime/run.go
+++ b/pipeline/runtime/run.go
@@ -102,7 +102,7 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 
 	// Parse and upload savings to TI
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, CheckStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, checkStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/pipeline/runtime/run.go
+++ b/pipeline/runtime/run.go
@@ -102,7 +102,7 @@ func executeRunStep(ctx context.Context, f RunFunc, r *api.StartStepRequest, out
 
 	// Parse and upload savings to TI
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig, r.Envs)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, CheckStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/pipeline/runtime/runtest.go
+++ b/pipeline/runtime/runtest.go
@@ -82,7 +82,7 @@ func executeRunTestStep(ctx context.Context, f RunFunc, r *api.StartStepRequest,
 
 	// Parse and upload savings to TI
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, CheckStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, checkStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/pipeline/runtime/runtest.go
+++ b/pipeline/runtime/runtest.go
@@ -82,7 +82,7 @@ func executeRunTestStep(ctx context.Context, f RunFunc, r *api.StartStepRequest,
 
 	// Parse and upload savings to TI
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig, r.Envs)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, CheckStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -127,7 +127,7 @@ func executeRunTestsV2Step(ctx context.Context, f RunFunc, r *api.StartStepReque
 	}
 
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, CheckStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, checkStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -127,7 +127,7 @@ func executeRunTestsV2Step(ctx context.Context, f RunFunc, r *api.StartStepReque
 	}
 
 	if tiConfig.GetParseSavings() {
-		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, timeTakenMs, tiConfig, r.Envs)
+		optimizationState = savings.ParseAndUploadSavings(ctx, r.WorkingDir, log, step.Name, CheckStepSuccess(exited, err), timeTakenMs, tiConfig, r.Envs)
 	}
 
 	useCINewGodotEnvVersion := false

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const restoreCacheHarnessStepId = "restore-cache-harness"
+const restoreCacheHarnessStepID = "restore-cache-harness"
 
 func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Logger, stepID string, stepSuccess bool, cmdTimeTaken int64,
 	tiConfig *tiCfg.Cfg, envs map[string]string) types.IntelligenceExecutionState {
@@ -66,7 +66,7 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 	}
 
 	// Cache Intel savings
-	if stepID == restoreCacheHarnessStepId {
+	if stepID == restoreCacheHarnessStepID {
 		cacheIntelState := types.FULL_RUN
 		if stepSuccess {
 			cacheIntelState = types.OPTIMIZED

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -13,7 +13,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Logger, stepID string, cmdTimeTaken int64,
+const restoreCacheHarnessStepId = "restore-cache-harness"
+
+func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Logger, stepID string, stepSuccess bool, cmdTimeTaken int64,
 	tiConfig *tiCfg.Cfg, envs map[string]string) types.IntelligenceExecutionState {
 	states := make([]types.IntelligenceExecutionState, 0)
 	// Cache Savings
@@ -62,7 +64,16 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 			}
 		}
 	}
-	// Cache Intel savings (Placeholder)
+
+	// Cache Intel savings
+	if stepID == restoreCacheHarnessStepId {
+		cacheIntelState := types.FULL_RUN
+		if stepSuccess {
+			cacheIntelState = types.OPTIMIZED
+		}
+		states = append(states, cacheIntelState)
+	}
+
 	return getStepState(states)
 }
 


### PR DESCRIPTION
If the cache intel restore step is successful then it is OPTIMZED. If it exists but not successful it is a FULL_RUN

Tested on devspace, we can see optimization state, time saved populated and showing on UI
<img width="1728" alt="Screenshot 2024-07-08 at 1 50 10 PM" src="https://github.com/harness/lite-engine/assets/114451080/d682263f-c4e5-47c3-8071-1ed64e200da3">