### PR TITLE
feat: [CI-13332]:  Add support for dotnet agent

### DIFF
--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -39,7 +39,7 @@ const (
 	waitTimeoutInSec  = 30
 	agentV2LinkLength = 3
 	dotNetAgentLinkIndex = 3
-	dotNetAgentProfilerGuid = "{86A1D712-8FAE-4ECD-9333-DB03F62E44FA}"
+	dotNetAgentProfilerGUID = "{86A1D712-8FAE-4ECD-9333-DB03F62E44FA}"
 	dotNetAgentV2Lib    = "net-agent.so"
 	dotNetAgentV2Zip    = "net-agent.zip"
 	dotNetAgentV2Path   = "/dotnet/v2/"
@@ -88,7 +88,8 @@ func executeRunTestsV2Step(ctx context.Context, f RunFunc, r *api.StartStepReque
 		agentPaths["python"] = pythonArtifactDir
 
 		if len(links) > dotNetAgentLinkIndex {
-			dotNetArtifactDir, err := downloadDotNetAgent(ctx, tmpFilePath, links[dotNetAgentLinkIndex].URL, fs, log)
+			var dotNetArtifactDir string
+			dotNetArtifactDir, err = downloadDotNetAgent(ctx, tmpFilePath, links[dotNetAgentLinkIndex].URL, fs, log)
 			if err == nil {
 				agentPaths["dotnet"] = dotNetArtifactDir
 			} else {
@@ -447,18 +448,18 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 
 	// .Net
 	if _, exists := agentPaths["dotnet"]; exists {
-		dotNetJsonFilePath, err := createDotNetConfigFile(tmpFilePath, fs, log, filterFilePath, outDir, splitIdx)
+		dotNetJSONFilePath, err := createDotNetConfigFile(tmpFilePath, fs, log, filterFilePath, outDir, splitIdx)
 		if err != nil {
-			log.WithError(err).Errorln(fmt.Sprintf("could not create dotnet agent config file in path %s", dotNetJsonFilePath))
+			log.WithError(err).Errorln(fmt.Sprintf("could not create dotnet agent config file in path %s", dotNetJSONFilePath))
 			return "", "", err
 		}
 
 		dotNetAgentPath := fmt.Sprintf("%s%s%s", tmpFilePath, dotNetAgentV2Path, dotNetAgentV2Lib)
 
 		envs["CORECLR_PROFILER_PATH"] = dotNetAgentPath
-		envs["CORECLR_PROFILER"] = dotNetAgentProfilerGuid
+		envs["CORECLR_PROFILER"] = dotNetAgentProfilerGUID
 		envs["CORECLR_ENABLE_PROFILING"] = "1"
-		envs["TI_DOTNET_CONFIG"] = dotNetJsonFilePath
+		envs["TI_DOTNET_CONFIG"] = dotNetJSONFilePath
 	}
 
 	return preCmd, filterFilePath, nil

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -593,8 +593,8 @@ func collectTestReportsAndCg(ctx context.Context, log *logrus.Logger, r *api.Sta
 	}
 
 	if len(r.TestReport.Junit.Paths) == 0 {
-		// If there are no paths specified, set Paths[0] to include all XML files
-		r.TestReport.Junit.Paths = []string{"**/*.xml"}
+		// If there are no paths specified, set Paths[0] to include all XML files and all TRX files
+		r.TestReport.Junit.Paths = []string{"**/*.xml", "**/*.trx"}
 	}
 
 	reportStart := time.Now()

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -30,20 +30,20 @@ import (
 )
 
 const (
-	outDir            = "%s/ti/v2/callgraph/cg/" // path passed as outDir in the config.ini file
-	javaAgentV2Arg    = "-javaagent:%s=%s"
-	javaAgentV2Jar    = "java-agent.jar"
-	javaAgentV2Path   = "/java/v2/"
-	filterV2Dir       = "%s/ti/v2/filter"
-	configV2Dir       = "%s/ti/v2/java/config"
-	waitTimeoutInSec  = 30
-	agentV2LinkLength = 3
-	dotNetAgentLinkIndex = 3
+	outDir                  = "%s/ti/v2/callgraph/cg/" // path passed as outDir in the config.ini file
+	javaAgentV2Arg          = "-javaagent:%s=%s"
+	javaAgentV2Jar          = "java-agent.jar"
+	javaAgentV2Path         = "/java/v2/"
+	filterV2Dir             = "%s/ti/v2/filter"
+	configV2Dir             = "%s/ti/v2/java/config"
+	waitTimeoutInSec        = 30
+	agentV2LinkLength       = 3
+	dotNetAgentLinkIndex    = 3
 	dotNetAgentProfilerGUID = "{86A1D712-8FAE-4ECD-9333-DB03F62E44FA}"
-	dotNetAgentV2Lib    = "net-agent.so"
-	dotNetAgentV2Zip    = "net-agent.zip"
-	dotNetAgentV2Path   = "/dotnet/v2/"
-	dotNetConfigV2Dir   = "%s/ti/v2/dotnet/config"
+	dotNetAgentV2Lib        = "net-agent.so"
+	dotNetAgentV2Zip        = "net-agent.zip"
+	dotNetAgentV2Path       = "/dotnet/v2/"
+	dotNetConfigV2Dir       = "%s/ti/v2/dotnet/config"
 )
 
 // Ignoring optimization state for now
@@ -397,7 +397,7 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 				return "", "", err
 			}
 		}
-		
+
 		tiConfig.UnlockZip()
 	}
 

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -94,7 +94,6 @@ func executeRunTestsV2Step(ctx context.Context, f RunFunc, r *api.StartStepReque
 			} else {
 				log.Warningln(".net agent installation failed. Continuing without .net support.")
 			}
-			
 		}
 
 		isPsh := IsPowershell(step.Entrypoint)

--- a/pipeline/runtime/runtestsV2.go
+++ b/pipeline/runtime/runtestsV2.go
@@ -19,6 +19,7 @@ import (
 	"github.com/harness/lite-engine/pipeline"
 	tiCfg "github.com/harness/lite-engine/ti/config"
 	"github.com/harness/lite-engine/ti/instrumentation"
+	"github.com/harness/lite-engine/ti/instrumentation/csharp"
 	"github.com/harness/lite-engine/ti/instrumentation/java"
 	"github.com/harness/lite-engine/ti/instrumentation/python"
 	"github.com/harness/lite-engine/ti/instrumentation/ruby"
@@ -37,6 +38,12 @@ const (
 	configV2Dir       = "%s/ti/v2/java/config"
 	waitTimeoutInSec  = 30
 	agentV2LinkLength = 3
+	dotNetAgentLinkIndex = 3
+	dotNetAgentProfilerGuid = "{86A1D712-8FAE-4ECD-9333-DB03F62E44FA}"
+	dotNetAgentV2Lib    = "net-agent.so"
+	dotNetAgentV2Zip    = "net-agent.zip"
+	dotNetAgentV2Path   = "/dotnet/v2/"
+	dotNetConfigV2Dir   = "%s/ti/v2/dotnet/config"
 )
 
 // Ignoring optimization state for now
@@ -79,6 +86,16 @@ func executeRunTestsV2Step(ctx context.Context, f RunFunc, r *api.StartStepReque
 			return nil, nil, nil, nil, nil, string(optimizationState), fmt.Errorf("failed to download Python agent")
 		}
 		agentPaths["python"] = pythonArtifactDir
+
+		if len(links) > dotNetAgentLinkIndex {
+			dotNetArtifactDir, err := downloadDotNetAgent(ctx, tmpFilePath, links[dotNetAgentLinkIndex].URL, fs, log)
+			if err == nil {
+				agentPaths["dotnet"] = dotNetArtifactDir
+			} else {
+				log.Warningln(".net agent installation failed. Continuing without .net support.")
+			}
+			
+		}
 
 		isPsh := IsPowershell(step.Entrypoint)
 		preCmd, filterfilePath, err := getPreCmd(r.WorkingDir, tmpFilePath, fs, log, r.Envs, agentPaths, isPsh, tiConfig)
@@ -275,6 +292,43 @@ func createJavaConfigFile(tmpDir string, fs filesystem.FileSystem, log *logrus.L
 	return iniFile, nil // path of config.ini file
 }
 
+func createDotNetConfigFile(tmpDir string, fs filesystem.FileSystem, log *logrus.Logger, filterfilePath, outDir string, splitIdx int) (string, error) {
+	jsonFileDir := fmt.Sprintf(dotNetConfigV2Dir, tmpDir)
+	err := fs.MkdirAll(jsonFileDir, os.ModePerm)
+	if err != nil {
+		log.WithError(err).Errorln(fmt.Sprintf("could not create nested directory %s", jsonFileDir))
+		return "", err
+	}
+	// create file paths with splitidx for splitting
+	jsonFile := fmt.Sprintf("%s/config_%d.json", jsonFileDir, splitIdx)
+
+	data := fmt.Sprintf(`{
+		"logging":{
+			"level": "information",
+			"console": "false",
+			"file": "%s/log"
+		},
+		"outdir": "%s",
+		"filterFile": "%s"
+	}`, outDir, outDir, filterfilePath)
+
+	log.Infof("Writing to %s with config:\n%s", jsonFile, data)
+	f, err := fs.Create(jsonFile)
+	if err != nil {
+		log.WithError(err).Errorln(fmt.Sprintf("could not create config file %s", jsonFile))
+		return "", err
+	}
+
+	_, err = f.WriteString(data)
+	defer f.Close()
+	if err != nil {
+		log.WithError(err).Errorln(fmt.Sprintf("could not write %s to config file %s", data, jsonFile))
+		return "", err
+	}
+
+	return jsonFile, nil // path of config.json file
+}
+
 // Here we are setting up env var to invoke agant along with creating config file and .bazelrc file
 //
 //nolint:funlen,gocyclo,lll
@@ -336,6 +390,14 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 		if err != nil {
 			return "", "", err
 		}
+
+		if agentPath, exists := agentPaths["dotnet"]; exists {
+			err = csharp.Unzip(agentPath, log)
+			if err != nil {
+				return "", "", err
+			}
+		}
+		
 		tiConfig.UnlockZip()
 	}
 
@@ -384,6 +446,22 @@ func getPreCmd(workspace, tmpFilePath string, fs filesystem.FileSystem, log *log
 		}
 	}
 
+	// .Net
+	if _, exists := agentPaths["dotnet"]; exists {
+		dotNetJsonFilePath, err := createDotNetConfigFile(tmpFilePath, fs, log, filterFilePath, outDir, splitIdx)
+		if err != nil {
+			log.WithError(err).Errorln(fmt.Sprintf("could not create dotnet agent config file in path %s", dotNetJsonFilePath))
+			return "", "", err
+		}
+
+		dotNetAgentPath := fmt.Sprintf("%s%s%s", tmpFilePath, dotNetAgentV2Path, dotNetAgentV2Lib)
+
+		envs["CORECLR_PROFILER_PATH"] = dotNetAgentPath
+		envs["CORECLR_PROFILER"] = dotNetAgentProfilerGuid
+		envs["CORECLR_ENABLE_PROFILING"] = "1"
+		envs["TI_DOTNET_CONFIG"] = dotNetJsonFilePath
+	}
+
 	return preCmd, filterFilePath, nil
 }
 
@@ -415,6 +493,18 @@ func downloadPythonAgent(ctx context.Context, path, pythonAgentV2Url string, fs 
 	err := instrumentation.DownloadFile(ctx, dir, pythonAgentV2Url, fs)
 	if err != nil {
 		log.WithError(err).Errorln("could not download python agent")
+		return "", err
+	}
+	return installDir, nil
+}
+
+func downloadDotNetAgent(ctx context.Context, path, dotNetAgentV2Url string, fs filesystem.FileSystem, log *logrus.Logger) (string, error) {
+	dotNetAgentPath := fmt.Sprintf("%s%s", dotNetAgentV2Path, dotNetAgentV2Zip)
+	dir := filepath.Join(path, dotNetAgentPath)
+	installDir := filepath.Dir(dir)
+	err := instrumentation.DownloadFile(ctx, dir, dotNetAgentV2Url, fs)
+	if err != nil {
+		log.WithError(err).Errorln("could not download .net agent")
 		return "", err
 	}
 	return installDir, nil

--- a/ti/instrumentation/csharp/helper.go
+++ b/ti/instrumentation/csharp/helper.go
@@ -2,11 +2,14 @@ package csharp
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/harness/lite-engine/ti/instrumentation/common"
 	ti "github.com/harness/ti-client/types"
 	"github.com/mattn/go-zglob"
+	"github.com/mholt/archiver/v3"
+	"github.com/sirupsen/logrus"
 )
 
 // GetCsharpTests returns list of RunnableTests in the workspace with cs extension.
@@ -58,4 +61,21 @@ func ParseCsharpNode(filename string, testGlobs []string) (*common.Node, error) 
 	parts := strings.Split(f, "/")
 	node.Class = parts[len(parts)-1]
 	return &node, nil
+}
+
+// Unzip unzips the dotnet agent zip file
+// In case of errors, return the error
+func Unzip(agentInstallDir string, log *logrus.Logger) (err error) {
+	zip := archiver.Zip{
+		OverwriteExisting: true,
+	}
+	
+	// Unzip everything at agentInstallDir/
+	err = zip.Unarchive(filepath.Join(agentInstallDir, "dotnet-agent.zip"), agentInstallDir)
+	if err != nil {
+		log.WithError(err).Println("could not unzip the .net agent")
+		return err
+	}
+
+	return nil
 }

--- a/ti/instrumentation/csharp/helper.go
+++ b/ti/instrumentation/csharp/helper.go
@@ -69,7 +69,7 @@ func Unzip(agentInstallDir string, log *logrus.Logger) (err error) {
 	zip := archiver.Zip{
 		OverwriteExisting: true,
 	}
-	
+
 	// Unzip everything at agentInstallDir/
 	err = zip.Unarchive(filepath.Join(agentInstallDir, "dotnet-agent.zip"), agentInstallDir)
 	if err != nil {

--- a/ti/instrumentation/utils.go
+++ b/ti/instrumentation/utils.go
@@ -511,7 +511,7 @@ func DownloadFile(ctx context.Context, path, url string, fs filesystem.FileSyste
 
 func GetV2AgentDownloadLinks(ctx context.Context, config *tiCfg.Cfg) ([]ti.DownloadLink, error) {
 	c := config.GetClient()
-	links, err := c.DownloadLink(ctx, "RunTestV2", runtime.GOOS, runtime.GOOS, "", "", "")
+	links, err := c.DownloadLink(ctx, "RunTestV2", runtime.GOOS, runtime.GOARCH, "", "", "")
 	if err != nil {
 		return links, err
 	}

--- a/ti/report/parser/junit/gojunit/ingesters.go
+++ b/ti/report/parser/junit/gojunit/ingesters.go
@@ -33,8 +33,8 @@ func IngestReader(reader io.Reader, rootSuiteName string, trxFormat bool) ([]Sui
 	var (
 		suiteChan = make(chan Suite)
 		suites    = make([]Suite, 0)
-		nodes []xmlNode
-		err error
+		nodes     []xmlNode
+		err       error
 	)
 
 	if trxFormat {

--- a/ti/report/parser/junit/gojunit/parse.go
+++ b/ti/report/parser/junit/gojunit/parse.go
@@ -244,18 +244,21 @@ func handleUnitTestResultNode(decoder *xml.Decoder, startElement *xml.StartEleme
 		(*failed)++
 		failureNode := xmlNode{XMLName: xml.Name{Local: "failure"}}
 		testCase.Nodes = append(testCase.Nodes, failureNode)
+		failureNode.Attrs = make(map[string]string)
 		failureNode.Attrs["message"] = u.Message
 		failureNode.Content = []byte(u.StackTrace)
 	} else if u.Outcome == "" || u.Outcome == "Error" {
 		(*errors)++
 		errorNode := xmlNode{XMLName: xml.Name{Local: "error"}}
 		testCase.Nodes = append(testCase.Nodes, errorNode)
+		errorNode.Attrs = make(map[string]string)
 		errorNode.Attrs["message"] = u.Message
 		errorNode.Content = []byte(u.StackTrace)
 	} else if u.Outcome != "Failed" && u.Outcome != "Passed" {
 		(*skipped)++
 		skippedNode := xmlNode{XMLName: xml.Name{Local: "skipped"}}
 		testCase.Nodes = append(testCase.Nodes, skippedNode)
+		skippedNode.Attrs = make(map[string]string)
 		skippedNode.Attrs["message"] = u.Message
 		skippedNode.Content = []byte(u.StackTrace)
 	}

--- a/ti/report/parser/junit/gojunit/parse.go
+++ b/ti/report/parser/junit/gojunit/parse.go
@@ -231,8 +231,6 @@ func handleUnitTestResultNode(decoder *xml.Decoder, startElement *xml.StartEleme
 	testCase.Attrs = make(map[string]string)
 	testCase.Attrs["id"] = u.TestID
 
-	var finish time.Time
-	var start time.Time
 	var testDuration time.Time
 
 	if u.Outcome == "Failed" {


### PR DESCRIPTION
## Description

Adding support for .Net to TI
This includes:
* Downloading the agent's archive
* Unzipping the archive
* Configuring the environment variables and writing a configuration file
* Parsing the results - for .Net it can support JUnit and TRX formats, so here we add support for TRX by converting them back to JUnit format in memory and letting the process continue as is

One thing to note - as opposed to other agents, .net is added later to the v2 step, so we don't prevent the use of the v2 step in case the .net agent is failed to download - we would just initiate a warning and won't apply the .net changes.

This change requires the changes from this PR: https://github.com/wings-software/harness-ti/pull/170 but it wouldn't fail if they are missing.

## Testing

* Tested with and without the physical agent being present
* Tested in Devspace and a local dlite setup:
  * Validated the ability to parse the TRX files and convert to JUnit (also tested separately outside of the lite engine)
  * Validated that the agent is being picked up when present. No real testing has been done on validating the actual agent yet as this is on a different task. Currently, the agent is not available, so this code won't do a lot.

## Screenshots
![image](https://github.com/user-attachments/assets/9ee72738-7572-4354-bb9d-fe7582b48fee)

![image](https://github.com/user-attachments/assets/5eac64c4-35b4-401d-87d0-30ae2da1874f)
