### PR TITLE
[feat]: [CI-13579]: Return  Optimization state for Failed Step

### DIFF
--- a/pipeline/runtime/step_executor.go
+++ b/pipeline/runtime/step_executor.go
@@ -451,5 +451,5 @@ func convertPollResponse(r *api.PollStepResponse) api.VMTaskExecutionResponse {
 	if r.Error == "" {
 		return api.VMTaskExecutionResponse{CommandExecutionStatus: api.Success, OutputVars: r.Outputs, Artifact: r.Artifact, Outputs: r.OutputV2, OptimizationState: r.OptimizationState}
 	}
-	return api.VMTaskExecutionResponse{CommandExecutionStatus: api.Failure, ErrorMessage: r.Error}
+	return api.VMTaskExecutionResponse{CommandExecutionStatus: api.Failure, ErrorMessage: r.Error, OptimizationState: r.OptimizationState}
 }

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -65,6 +65,11 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 		}
 	}
 
+	// If the Step Fails then we should return the savings state only for restore-cache (CACHE_INTEL). This is to match the current beahavior in K8
+	if !stepSuccess {
+		states = make([]types.IntelligenceExecutionState, 0)
+	}
+
 	// Cache Intel savings
 	if stepID == restoreCacheHarnessStepID {
 		cacheIntelState := types.FULL_RUN

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -65,7 +65,7 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 		}
 	}
 
-	// If the Step Fails then we should return the savings state only for restore-cache (CACHE_INTEL). This is to match the current beahavior in K8
+	// If the Step Fails then we should return the savings state only for restore-cache (CACHE_INTEL). This is to match the current behavior in K8
 	if !stepSuccess {
 		states = make([]types.IntelligenceExecutionState, 0)
 	}

--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -65,6 +65,7 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 		}
 	}
 
+	// No Savings should happen beyond this except for Cache Intel
 	// If the Step Fails then we should return the savings state only for restore-cache (CACHE_INTEL). This is to match the current behavior in K8
 	if !stepSuccess {
 		states = make([]types.IntelligenceExecutionState, 0)


### PR DESCRIPTION
Currently optimization state is not returned for a failed step. This should be done to make sure cache intel FULL_RUN is saved since cache intel is a FULL_RUN if the restore-cache-harness step fails

Tested on local

FULL_RUN (where restore step fails)

We can see that we are returning the optimization state
<img width="1639" alt="Screenshot 2024-07-24 at 12 12 32 PM" src="https://github.com/user-attachments/assets/2148fda3-7b0a-4e8f-bc4c-97e29403a20e">
<img width="1728" alt="Screenshot 2024-07-24 at 12 15 46 PM" src="https://github.com/user-attachments/assets/293b2e51-a58a-4d6e-b71d-1b0e2a923536">

Optimized Run
<img width="1639" alt="Screenshot 2024-07-24 at 12 14 38 PM" src="https://github.com/user-attachments/assets/e9bd09d9-0e48-427c-9f9a-51dc0b7d8ab9">
<img width="1728" alt="Screenshot 2024-07-24 at 12 16 06 PM" src="https://github.com/user-attachments/assets/175d491b-e01a-4ec9-aa58-4577e54383de">