### PR TITLE
support for overwriting existing files

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/harness/lite-engine/engine/exec"
 	"github.com/harness/lite-engine/engine/spec"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -185,8 +186,9 @@ func createFiles(paths []*spec.File) error {
 		// make the file writable (if it exists)
 		if _, err := os.Stat(path); err == nil {
 			if err = os.Chmod(path, 0644); err != nil {
-				return errors.Wrap(err,
-					fmt.Sprintf("failed to set permissions for file on host path: %q", path))
+				logrus.Error(errors.Wrap(err,
+					fmt.Sprintf("failed to set permissions for file on host path: %q", path)))
+				continue
 			}
 		}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -182,6 +182,14 @@ func createFiles(paths []*spec.File) error {
 
 		path := f.Path
 
+		// make the file writable (if it exists)
+		if _, err := os.Stat(path); err == nil {
+			if err = os.Chmod(path, 0644); err != nil {
+				return errors.Wrap(err,
+					fmt.Sprintf("failed to set permissions for file on host path: %q", path))
+			}
+		}
+
 		if f.IsDir {
 			// create a folder
 			if err := os.MkdirAll(path, fs.FileMode(f.Mode)); err != nil {
@@ -189,14 +197,6 @@ func createFiles(paths []*spec.File) error {
 					fmt.Sprintf("failed to create directory for host path: %q", path))
 			}
 			continue
-		}
-
-		// make the file writable (if it exists)
-		if _, err := os.Stat(path); err == nil {
-			if err = os.Chmod(path, 0644); err != nil {
-				return errors.Wrap(err,
-					fmt.Sprintf("failed to set permissions for file on host path: %q", path))
-			}
 		}
 
 		// Create (or overwrite) the file
@@ -214,7 +214,6 @@ func createFiles(paths []*spec.File) error {
 
 		_ = file.Close()
 
-		// Set the file mode to the desired permissions
 		if err = os.Chmod(path, fs.FileMode(f.Mode)); err != nil {
 			return errors.Wrap(err,
 				fmt.Sprintf("failed to change permissions for file on host path: %q", path))


### PR DESCRIPTION
Currently lite engine skips processing a file if it already exists. We should ideally overwrite the file with the content provided. Runner creates a exec task with some files. 
Updated createFiles func to check if file exists -> update permissions to write it -> log error in chmod -> continue with os.create (it will truncate existing files) 