### PR TITLE
[feat]: [CI-14185]: Dont explicitly check harness/buildkit in PLUGIN_…

### DIFF
--- a/ti/savings/savings.go
+++ b/ti/savings/savings.go
@@ -3,7 +3,6 @@ package savings
 import (
 	"context"
 	"strconv"
-	"strings"
 	"time"
 
 	tiCfg "github.com/harness/lite-engine/ti/config"
@@ -50,7 +49,7 @@ func ParseAndUploadSavings(ctx context.Context, workspace string, log *logrus.Lo
 
 	// DLC Savings
 	if cacheMetricsFile, found := envs["PLUGIN_CACHE_METRICS_FILE"]; found {
-		if opts, ok := envs["PLUGIN_BUILDER_DRIVER_OPTS"]; ok && strings.Contains(opts, "harness/buildkit") {
+		if _, ok := envs["PLUGIN_BUILDER_DRIVER_OPTS"]; ok {
 			dlcState, savingsRequest, err := dlc.ParseDlcSavings(cacheMetricsFile, log)
 			if err == nil {
 				states = append(states, dlcState)


### PR DESCRIPTION
…BUILDKIT_DRIVER_OPTS for DLC Parse Savings


Verified that we only send PLUGIN_BUILDER_DRIVER_OPTS incase of DLC parse savings and hence do not need to check the actual value of it. Checking the value will fail when we change where we host buildkit