### PR TITLE
[feat]: [CI-12024]: Gradle Build Cache Savings should only be Parsed Once

### DIFF
--- a/ti/savings/cache/gradle/parser.go
+++ b/ti/savings/cache/gradle/parser.go
@@ -52,12 +52,28 @@ func readHTMLFromFile(filePath string) (*html.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
 
 	content, err := io.ReadAll(file)
 	if err != nil {
+		file.Close() // Close the file in case of error
 		return nil, err
 	}
+
+	// Close the file before renaming it
+	err = file.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	// Append ".processed" to the file path
+	processedFilePath := filePath + ".processed"
+
+	// Rename the file to append ".processed". This ensures that the original file is not processed multiple times
+	err = os.Rename(filePath, processedFilePath)
+	if err != nil {
+		return nil, err
+	}
+
 	reader := strings.NewReader(string(content))
 	doc, err := html.Parse(reader)
 	if err != nil {


### PR DESCRIPTION
In this PR once we read a profile report we append it with .processed so that it isnt read again. This ensures that the original file is not processed by multiple steps

Tested on devspace

Without changes we can see that non build cache step after the build cache also is optimized
<img width="1715" alt="Screenshot 2024-09-16 at 11 44 24 PM" src="https://github.com/user-attachments/assets/af0b5bae-64f4-41d4-89fa-6c6ab22734ee">

After changes we can see that the step after the build cache step does not upload any optimization state and we can see that the profile file is not present anymore
![Uploading Screenshot 2024-09-17 at 10.22.19 AM.png…]()




