### PR TITLE
[feat]: [CI-14538]: remove http dependency

### DIFF
--- a/engine/docker/docker.go
+++ b/engine/docker/docker.go
@@ -44,7 +44,6 @@ const (
 	startContainerRetrySleepDuration = 5
 	networkMaxRetries                = 3
 	networkRetrySleepDuration        = 50
-	harnessHTTPProxy                 = "HARNESS_HTTP_PROXY"
 	harnessHTTPSProxy                = "HARNESS_HTTPS_PROXY"
 	harnessNoProxy                   = "HARNESS_NO_PROXY"
 	dockerServiceDir                 = "/etc/systemd/system/docker.service.d"
@@ -107,7 +106,7 @@ func (e *Docker) Setup(ctx context.Context, pipelineConfig *spec.PipelineConfig)
 	// creates the default temporary (local) volumes
 	// that are mounted into each container step.
 
-	if _, ok := pipelineConfig.Envs[harnessHTTPProxy]; ok {
+	if _, ok := pipelineConfig.Envs[harnessHTTPSProxy]; ok {
 		e.setProxyInDockerDaemon(ctx, pipelineConfig)
 	}
 
@@ -583,11 +582,10 @@ func (e *Docker) createNetworkWithRetries(ctx context.Context,
 }
 
 func (e *Docker) setProxyInDockerDaemon(ctx context.Context, pipelineConfig *spec.PipelineConfig) {
-	httpProxy := pipelineConfig.Envs[harnessHTTPProxy]
 	httpsProxy := pipelineConfig.Envs[harnessHTTPSProxy]
 	noProxy := pipelineConfig.Envs[harnessNoProxy]
 	if pipelineConfig.Platform.OS == windowsOS {
-		os.Setenv("HTTP_PROXY", httpProxy)
+		os.Setenv("HTTP_PROXY", httpsProxy)
 		os.Setenv("HTTPS_PROXY", httpsProxy)
 		os.Setenv("NO_PROXY", noProxy)
 
@@ -608,7 +606,7 @@ func (e *Docker) setProxyInDockerDaemon(ctx context.Context, pipelineConfig *spe
 	Environment="HTTP_PROXY=%s"
 	Environment="HTTPS_PROXY=%s"
 	Environment="NO_PROXY=%s"
-	`, httpProxy, httpsProxy, noProxy)
+	`, httpsProxy, httpsProxy, noProxy)
 
 		if err := os.WriteFile(httpProxyConfFilePath, []byte(proxyConf), filePermission); err != nil {
 			logger.FromContext(ctx).WithError(err).Infoln("Error writing proxy configuration")


### PR DESCRIPTION
Changes : removed http dependency as security concern from secops team
Tested both  http  & https traffic with https proxy in qa for this 
linux :
**http**: 
https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/SatyaTest/pipelines/secureConnectAuth_DockerBuildAndPush_Clone/deployments/6a_hG9xJTL-JYn3VI_rbGQ/pipeline?storeType=INLINE
**https**:
https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/SatyaTest/pipelines/secureConnectAuth_DockerBuildAndPush_Clone/executions/Dez39Ar6R--lUWoRv3iXBA/pipeline?storeType=INLINE&step=Ewkx2dbeRlO9mpTS4G0Dmw&stage=uoYKbi3QREe7RbiobBQo0A&childStage=&stageExecId=

windows : 
**http**:
https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/SatyaTest/pipelines/secureConnectAuth_DockerBuildAndPush_WINDOWS/executions/O2VcWZEFRqa3YRt5r6AyJw/pipeline?storeType=INLINE&step=siNHWBFWTGymnZ2vScKbvQ&stage=uJqVLw5mR7C56ed0VfAMuQ&childStage=&stageExecId=
**https**:
https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/SatyaTest/pipelines/secureConnectAuth_DockerBuildAndPush_WINDOWS/executions/Wo5JR57mSTO9lGhcmDhABg/pipeline?storeType=INLINE