### PR TITLE
fix: [CI-22127]: update go.mod toolchain directive to go1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/harness/lite-engine
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
## Summary
- Aligns `go.mod` toolchain directive from `go1.25.8` to `go1.25.9` to match the Dockerfile builder image (`golang:1.25.9-alpine`)
- The previous commit updated the Dockerfile but missed updating the toolchain line in `go.mod`

## Test plan
- [x] `go mod tidy` runs cleanly
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)